### PR TITLE
feat(growth_areas): link growth area rows to filtered VRM foreclosures list

### DIFF
--- a/templates/growth_areas.html
+++ b/templates/growth_areas.html
@@ -14,7 +14,7 @@
             <td>{{ s.rent_index }}</td>
             <td>{{ s.price_trend|floatformat:2 }}</td>
             <td>
-              <a href="/search?state={{ s.state }}&zip={{ s.zip_code }}">View Properties</a>
+              <a href="{% url 'vrm_properties_list' %}?state={{ s.state }}&zip={{ s.zip_code }}">View Foreclosures</a>
               |
               <a href="#" onclick="fetchHUD('{{ s.state }}','{{ s.zip_code }}'); return false;">Pull HUD</a>
             </td>


### PR DESCRIPTION
## Problem
Growth Areas page had a hardcoded link to generic search (`/search?state=...&zip=...`) instead of linking to the VRM foreclosures list view which provides more relevant results.

## Solution
- Replace hardcoded `/search?state={{ s.state }}&zip={{ s.zip_code }}` with `{% url 'vrm_properties_list' %}?state={{ s.state }}&zip={{ s.zip_code }}`
- Change link text from 'View Properties' to 'View Foreclosures'
- Verified `core/views.py` vrm_properties_list view reads 'state' and 'zip' GET params (matches filter form in templates/vrm_properties/list.html)

## Validation
- All pre-commit hooks pass
- All 160 tests pass
- URL pattern confirmed in core/urls.py: `vrm_properties_list`
