### PR TITLE
chore(growth_areas): remove non-functional Pull HUD link and JS stub

### DIFF
--- a/templates/growth_areas.html
+++ b/templates/growth_areas.html
@@ -15,8 +15,6 @@
             <td>{{ s.price_trend|floatformat:2 }}</td>
             <td>
               <a href="{% url 'vrm_properties_list' %}?state={{ s.state }}&zip={{ s.zip_code }}">View Foreclosures</a>
-              |
-              <a href="#" onclick="fetchHUD('{{ s.state }}','{{ s.zip_code }}'); return false;">Pull HUD</a>
             </td>
           </tr>
       {% empty %}
@@ -44,9 +42,5 @@
       {% endfor %}
     </tbody>
   </table>
-    <script>
-      async function fetchHUD(state, zip) {
-        alert(`Trigger HUD fetch for ${state} ${zip}. Run the management command in the server.`);
-      }
-    </script>
+
 {% endblock %}


### PR DESCRIPTION
## Problem

The Growth Areas page had a non-functional "Pull HUD" link that called `fetchHUD()` which only showed an `alert()` dialog. No server-side endpoint backed this call — it was a placeholder/stub that never worked.

## Solution

Per product decision (stated in the acceptance criteria): remove the dangling components now so they don't confuse users. If/when a real HUD-pull endpoint is built later, a proper link can be re-added.

**Removed:**
- The `|` pipe separator and the `<a href="#" onclick="fetchHUD(...)">Pull HUD</a>` link from each growth area row
- The entire `<script>` block containing `async function fetchHUD(state, zip) { alert(...) }`

**Preserved:**
- The "View Foreclosures" link pointing to `vrm_properties_list`
- All table headers, the CMA section, and all other template content

## Validation

| Check | Result |
|---|---|
| Pre-commit (all hooks) | Passed |
| pytest (160 test files) | 991 passed, 1 skipped |
| djlint | Passed |

## Risk

Low. No views, URLs, models, or backend code touched.
