### PR TITLE
fix(growth_areas): remove zip param from View Foreclosures link

### DIFF
--- a/templates/growth_areas.html
+++ b/templates/growth_areas.html
@@ -14,7 +14,7 @@
             <td>{{ s.rent_index }}</td>
             <td>{{ s.price_trend|floatformat:2 }}</td>
             <td>
-              <a href="{% url 'vrm_properties_list' %}?state={{ s.state }}&zip={{ s.zip_code }}">View Foreclosures</a>
+              <a href="{% url 'vrm_properties_list' %}?state={{ s.state }}">View Foreclosures</a>
             </td>
           </tr>
       {% empty %}


### PR DESCRIPTION
## Problem

The "View Foreclosures" link in `growth_areas.html` passed both `state` and `zip` params: `?state={{ s.state }}&zip={{ s.zip_code }}`. However, `GrowthArea` (the primary data source) has no `zip_code` field — row data comes from a union of `GrowthArea` (city/state only) and `MarketSnapshot` (zip/state). The zip param was silently empty/null for GrowthArea rows.

## Solution

Removed `&zip={{ s.zip_code }}`, leaving `?state={{ s.state }}` as the only filter parameter. The `vrm_properties_list` view (core/views.py:1100) handles state-only gracefully — it only filters by zip if the param is present and non-empty.

## Validation

| Check | Result |
|---|---|
| Pre-commit (all hooks) | Passed |
| pytest growth_areas integration tests | 2 passed |
| Core test suite (368 tests) | Passed |

## Risk

Low — single param removal, no views/backend touched.
