### PR TITLE
test(census): add tests for discover_places_in_state and growth_explorer view

### DIFF
--- a/core/templatetags/math_filters.py
+++ b/core/templatetags/math_filters.py
@@ -1,0 +1,23 @@
+"""Math template filters for percentage calculations.
+
+Provides:
+  - mul: multiply a value by a factor (float/int/Decimal)
+    Usage: {{ value|mul:100|floatformat:2 }}
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def mul(value, arg):
+    """Multiply the value by the argument."""
+    try:
+        return Decimal(str(value)) * Decimal(str(arg))
+    except (ValueError, TypeError, InvalidOperation):
+        return value

--- a/core/tests/test_growth_explorer.py
+++ b/core/tests/test_growth_explorer.py
@@ -1,0 +1,425 @@
+"""Tests for the Growth Area Explorer view (TASK-4).
+
+Covers:
+  - GET renders the state-picker form
+  - POST with invalid/missing state shows error
+  - POST with missing API keys shows error
+  - POST creates and updates GrowthArea rows correctly
+  - All places from one state share the same employment_growth_rate
+    (state-level BLS data — documented limitation, not a bug)
+  - Results sorted by composite_score descending
+
+All HTTP calls are mocked at the import site (core.views) — no real API calls.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from core.models import GrowthArea
+
+
+# ===========================================================================
+#  Fixtures / helpers
+# ===========================================================================
+
+
+def _mock_place(
+    place_code: str = "44000",
+    place_name: str = "Los Angeles",
+    population: int = 400000,
+) -> dict[str, object]:
+    """Build a place dict matching discover_places_in_state output."""
+    return {
+        "place_code": place_code,
+        "place_name": place_name,
+        "population": population,
+    }
+
+
+def _mock_census_metrics(
+    pop_growth: Decimal = Decimal("0.0526"),
+    income_growth: Decimal = Decimal("0.0897"),
+) -> dict[str, object]:
+    """Build a dict matching fetch_place_growth_metrics output."""
+    return {
+        "population_current": 400000,
+        "population_prior": 380000,
+        "population_growth_rate": pop_growth,
+        "median_income_current": Decimal("85000"),
+        "median_income_prior": Decimal("78000"),
+        "median_income_growth_rate": income_growth,
+    }
+
+
+API_ENV = {
+    "CENSUS_API_KEY": "test-census-key",
+    "BLS_API_KEY": "test-bls-key",
+}
+
+
+# ===========================================================================
+#  GET
+# ===========================================================================
+
+
+class TestGrowthExplorerGet:
+    """GET behaviour — renders the state-picker form."""
+
+    @pytest.mark.django_db
+    def test_get_returns_200(self, client) -> None:
+        """GET /growth-explorer/ returns 200 with states in context."""
+        resp = client.get(reverse("growth_explorer"))
+        assert resp.status_code == 200
+        assert "states" in resp.context
+        states = resp.context["states"]
+        assert len(states) > 0
+        assert states[0] == ("AL", "Alabama")
+
+    @pytest.mark.django_db
+    def test_get_renders_form_html(self, client) -> None:
+        """GET response contains the state-picker form elements."""
+        resp = client.get(reverse("growth_explorer"))
+        html = resp.content.decode()
+        assert "Growth Area Explorer" in html
+        assert 'name="state"' in html
+        assert "Analyze" in html or "Explore" in html or "Analyze Growth" in html
+
+
+# ===========================================================================
+#  POST — error paths
+# ===========================================================================
+
+
+class TestGrowthExplorerPostErrors:
+    """POST behaviour — error handling for invalid input and missing config."""
+
+    @pytest.mark.django_db
+    def test_empty_state_shows_error(self, client) -> None:
+        """POST with empty state returns form with error message."""
+        with patch.dict(os.environ, API_ENV):
+            resp = client.post(reverse("growth_explorer"), {"state": ""})
+
+        assert resp.status_code == 200
+        assert "Invalid state selected" in resp.content.decode()
+
+    @pytest.mark.django_db
+    def test_invalid_state_shows_error(self, client) -> None:
+        """POST with invalid state code returns form with error."""
+        with patch.dict(os.environ, API_ENV):
+            resp = client.post(reverse("growth_explorer"), {"state": "XX"})
+
+        assert resp.status_code == 200
+        assert "Invalid state selected" in resp.content.decode()
+
+    @pytest.mark.django_db
+    def test_missing_census_key_shows_error(self, client) -> None:
+        """POST without CENSUS_API_KEY shows configuration error."""
+        with patch.dict(os.environ, {"BLS_API_KEY": "test-bls-key"}, clear=True):
+            resp = client.post(reverse("growth_explorer"), {"state": "CA"})
+
+        assert resp.status_code == 200
+        assert "CENSUS_API_KEY" in resp.content.decode()
+
+    @pytest.mark.django_db
+    def test_missing_bls_key_shows_error(self, client) -> None:
+        """POST without BLS_API_KEY shows configuration error."""
+        with patch.dict(os.environ, {"CENSUS_API_KEY": "test-census-key"}, clear=True):
+            resp = client.post(reverse("growth_explorer"), {"state": "CA"})
+
+        assert resp.status_code == 200
+        assert "BLS_API_KEY" in resp.content.decode()
+
+    @patch("core.views.discover_places_in_state")
+    @pytest.mark.django_db
+    def test_no_places_found_shows_error(
+        self, mock_discover: MagicMock, client
+    ) -> None:
+        """POST that finds no places returns error message."""
+        mock_discover.return_value = []
+
+        with patch.dict(os.environ, API_ENV):
+            resp = client.post(reverse("growth_explorer"), {"state": "WY"})
+
+        assert resp.status_code == 200
+        assert "No places found" in resp.content.decode()
+
+    @patch("core.views.discover_places_in_state")
+    @pytest.mark.django_db
+    def test_place_without_census_data_skipped(
+        self, mock_discover: MagicMock, client
+    ) -> None:
+        """A place that returns None from fetch_place_growth_metrics is skipped
+        (not included in results, no GrowthArea created)."""
+        mock_discover.return_value = [
+            _mock_place("44000", "Good City", 400000),
+            _mock_place("55000", "Skip City", 100000),
+        ]
+
+        with (
+            patch.dict(os.environ, API_ENV),
+            patch("core.views.fetch_employment_growth") as mock_emp_growth,
+            patch("core.views.fetch_place_growth_metrics") as mock_census,
+            patch("core.views.fetch_housing_demand_index") as mock_housing,
+        ):
+            mock_emp_growth.return_value = Decimal("0.0300")
+            # First call returns data, second call returns None (fail)
+            mock_census.side_effect = [
+                _mock_census_metrics(),
+                None,
+            ]
+            mock_housing.return_value = 80
+
+            resp = client.post(reverse("growth_explorer"), {"state": "CA"})
+
+        assert resp.status_code == 200
+        # Only the successful place is in the results
+        assert GrowthArea.objects.filter(city_name="Good City").exists()
+        assert not GrowthArea.objects.filter(city_name="Skip City").exists()
+        html = resp.content.decode()
+        assert "Good City" in html
+        assert "Skip City" not in html
+
+
+# ===========================================================================
+#  POST — success paths
+# ===========================================================================
+
+
+class TestGrowthExplorerPostSuccess:
+    """POST behaviour — successful analysis creates/updates GrowthArea rows."""
+
+    @patch("core.views.discover_places_in_state")
+    @patch("core.views.fetch_employment_growth")
+    @patch("core.views.fetch_place_growth_metrics")
+    @patch("core.views.fetch_housing_demand_index")
+    @pytest.mark.django_db
+    def test_creates_growth_areas(
+        self,
+        mock_housing: MagicMock,
+        mock_census: MagicMock,
+        mock_employment: MagicMock,
+        mock_discover: MagicMock,
+        client,
+    ) -> None:
+        """Successful POST creates GrowthArea rows for each place."""
+        mock_discover.return_value = [
+            _mock_place("44000", "Los Angeles", 400000),
+            _mock_place("66000", "San Diego", 100000),
+        ]
+        mock_employment.return_value = Decimal("0.0450")
+        mock_census.return_value = _mock_census_metrics()
+        mock_housing.return_value = 85
+
+        with patch.dict(os.environ, API_ENV):
+            resp = client.post(reverse("growth_explorer"), {"state": "CA"})
+
+        assert resp.status_code == 200
+        assert GrowthArea.objects.filter(state="CA", city_name="Los Angeles").exists()
+        assert GrowthArea.objects.filter(state="CA", city_name="San Diego").exists()
+
+        la = GrowthArea.objects.get(state="CA", city_name="Los Angeles")
+        # DecimalField(max_digits=6, decimal_places=2) rounds to 2dp
+        assert la.employment_growth_rate == Decimal("0.04")  # 0.0450 → 0.04
+        assert la.housing_demand_index == 85
+        assert la.metro_area == "Los Angeles"
+
+    @patch("core.views.discover_places_in_state")
+    @patch("core.views.fetch_employment_growth")
+    @patch("core.views.fetch_place_growth_metrics")
+    @patch("core.views.fetch_housing_demand_index")
+    @pytest.mark.django_db
+    def test_updates_existing_growth_area(
+        self,
+        mock_housing: MagicMock,
+        mock_census: MagicMock,
+        mock_employment: MagicMock,
+        mock_discover: MagicMock,
+        client,
+    ) -> None:
+        """POST updates an existing GrowthArea with fresh data."""
+        GrowthArea.objects.create(
+            state="CA",
+            city_name="Los Angeles",
+            metro_area="Los Angeles",
+            population_growth_rate=Decimal("0.0100"),
+            employment_growth_rate=Decimal("0.0200"),
+            median_income_growth=Decimal("0.0300"),
+            housing_demand_index=50,
+            data_timestamp=timezone.now() - timedelta(days=30),
+        )
+
+        mock_discover.return_value = [_mock_place("44000", "Los Angeles", 410000)]
+        mock_employment.return_value = Decimal("0.0550")
+        mock_census.return_value = _mock_census_metrics(
+            pop_growth=Decimal("0.0789"),
+            income_growth=Decimal("0.1538"),
+        )
+        mock_housing.return_value = 90
+
+        with patch.dict(os.environ, API_ENV):
+            resp = client.post(reverse("growth_explorer"), {"state": "CA"})
+
+        assert resp.status_code == 200
+        la = GrowthArea.objects.get(state="CA", city_name="Los Angeles")
+        # DecimalField(max_digits=6, decimal_places=2) rounds to 2dp
+        assert la.population_growth_rate == Decimal("0.08")  # 0.0789 → 0.08
+        assert la.employment_growth_rate == Decimal("0.06")  # 0.0550 → 0.06
+        assert la.median_income_growth == Decimal("0.15")  # 0.1538 → 0.15
+        assert la.housing_demand_index == 90
+
+    @patch("core.views.discover_places_in_state")
+    @patch("core.views.fetch_employment_growth")
+    @patch("core.views.fetch_place_growth_metrics")
+    @patch("core.views.fetch_housing_demand_index")
+    @pytest.mark.django_db
+    def test_employment_growth_is_state_level(
+        self,
+        mock_housing: MagicMock,
+        mock_census: MagicMock,
+        mock_employment: MagicMock,
+        mock_discover: MagicMock,
+        client,
+    ) -> None:
+        """All places from one state share the same employment_growth_rate,
+        because the view calls fetch_employment_growth() once and reuses
+        the result for every place. This is documented, expected behaviour
+        (BLS does not publish place-level employment growth)."""
+        mock_discover.return_value = [
+            _mock_place("44000", "Los Angeles", 400000),
+            _mock_place("66000", "San Diego", 100000),
+            _mock_place("70000", "San Jose", 80000),
+        ]
+        mock_employment.return_value = Decimal("0.0375")  # single state-level value
+        mock_census.return_value = _mock_census_metrics()
+        mock_housing.return_value = 75
+
+        with patch.dict(os.environ, API_ENV):
+            resp = client.post(reverse("growth_explorer"), {"state": "CA"})
+
+        assert resp.status_code == 200
+        areas = GrowthArea.objects.filter(state="CA")
+        rates = {ga.employment_growth_rate for ga in areas}
+        assert len(rates) == 1, (
+            f"Expected all places to share the same employment_growth_rate, got {rates}"
+        )
+        # DecimalField(max_digits=6, decimal_places=2) rounds to 2dp
+        assert rates.pop() == Decimal("0.04")  # 0.0375 → 0.04
+
+    @patch("core.views.discover_places_in_state")
+    @patch("core.views.fetch_employment_growth")
+    @patch("core.views.fetch_place_growth_metrics")
+    @patch("core.views.fetch_housing_demand_index")
+    @pytest.mark.django_db
+    def test_results_sorted_by_composite_score(
+        self,
+        mock_housing: MagicMock,
+        mock_census: MagicMock,
+        mock_employment: MagicMock,
+        mock_discover: MagicMock,
+        client,
+    ) -> None:
+        """Results in the response context are sorted by composite_score desc.
+
+        We give each place different data so they produce different scores,
+        then verify the render context order."""
+        mock_discover.return_value = [
+            _mock_place("44000", "Los Angeles", 400000),
+            _mock_place("66000", "San Diego", 100000),
+            _mock_place("70000", "San Jose", 80000),
+        ]
+        mock_employment.return_value = Decimal("0.0450")
+
+        # Each place gets different growth data -> different composite_score
+        mock_census.side_effect = [
+            _mock_census_metrics(
+                pop_growth=Decimal("0.1000"), income_growth=Decimal("0.1200")
+            ),  # Los Angeles — high
+            _mock_census_metrics(
+                pop_growth=Decimal("0.0200"), income_growth=Decimal("0.0300")
+            ),  # San Diego — low
+            _mock_census_metrics(
+                pop_growth=Decimal("0.0500"), income_growth=Decimal("0.0600")
+            ),  # San Jose — medium
+        ]
+        mock_housing.side_effect = [90, 60, 75]
+
+        with patch.dict(os.environ, API_ENV):
+            resp = client.post(reverse("growth_explorer"), {"state": "CA"})
+
+        assert resp.status_code == 200
+        results = resp.context["results"]
+
+        # Verify scores are in descending order
+        scores = [r["growth_area"].composite_score for r in results]
+        assert scores == sorted(scores, reverse=True), (
+            f"Expected composite_scores in descending order, got {scores}"
+        )
+
+        # Sanity: Los Angeles (high growth) should rank higher than San Diego (low)
+        names_in_order = [r["place_name"] for r in results]
+        assert names_in_order.index("Los Angeles") < names_in_order.index(
+            "San Diego"
+        ), f"Los Angeles should rank above San Diego, got order: {names_in_order}"
+
+    @patch("core.views.discover_places_in_state")
+    @patch("core.views.fetch_employment_growth")
+    @patch("core.views.fetch_place_growth_metrics")
+    @patch("core.views.fetch_housing_demand_index")
+    @pytest.mark.django_db
+    def test_context_includes_emp_growth_value(
+        self,
+        mock_housing: MagicMock,
+        mock_census: MagicMock,
+        mock_employment: MagicMock,
+        mock_discover: MagicMock,
+        client,
+    ) -> None:
+        """The state-level employment growth value is passed to the template
+        context so the UI can display it with a footnote."""
+        mock_discover.return_value = [_mock_place("44000", "Los Angeles", 400000)]
+        mock_employment.return_value = Decimal("0.0375")
+        mock_census.return_value = _mock_census_metrics()
+        mock_housing.return_value = 80
+
+        with patch.dict(os.environ, API_ENV):
+            resp = client.post(reverse("growth_explorer"), {"state": "CA"})
+
+        assert resp.status_code == 200
+        assert resp.context["emp_growth"] == Decimal("0.0375")
+        assert resp.context["selected_state"] == "CA"
+
+    @patch("core.views.discover_places_in_state")
+    @patch("core.views.fetch_employment_growth")
+    @patch("core.views.fetch_place_growth_metrics")
+    @patch("core.views.fetch_housing_demand_index")
+    @pytest.mark.django_db
+    def test_housing_demand_defaults_to_50(
+        self,
+        mock_housing: MagicMock,
+        mock_census: MagicMock,
+        mock_employment: MagicMock,
+        mock_discover: MagicMock,
+        client,
+    ) -> None:
+        """When fetch_housing_demand_index returns None, the view defaults to 50."""
+        mock_discover.return_value = [_mock_place("44000", "Los Angeles", 400000)]
+        mock_employment.return_value = Decimal("0.0300")
+        mock_census.return_value = _mock_census_metrics()
+        mock_housing.return_value = None  # housing API fails
+
+        with patch.dict(os.environ, API_ENV):
+            resp = client.post(reverse("growth_explorer"), {"state": "CA"})
+
+        assert resp.status_code == 200
+        la = GrowthArea.objects.get(state="CA", city_name="Los Angeles")
+        assert la.housing_demand_index == 50, (
+            f"Expected default 50 when API returns None, got {la.housing_demand_index}"
+        )

--- a/templates/growth_explorer.html
+++ b/templates/growth_explorer.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Growth Area Explorer{% endblock %}
-{% load humanize %}
+{% load humanize math_filters %}
 {% block content %}
 <div class="page-header">
   <div>
@@ -8,6 +8,10 @@
     <p class="page-sub">Discover top growth places in a state — live Census/BLS data pull</p>
   </div>
 </div>
+
+{% if error %}
+  <div class="message message-error">{{ error }}</div>
+{% endif %}
 
 <form method="post" id="explorer-form" novalidate>
   {% csrf_token %}
@@ -17,7 +21,7 @@
       <label for="id_state" class="form-label">State</label>
       <select name="state" id="id_state" class="form-input" required>
         <option value="">— Choose a state —</option>
-        {% for code, name in US_STATES %}
+        {% for code, name in states %}
           <option value="{{ code }}">{{ name }} ({{ code }})</option>
         {% endfor %}
       </select>
@@ -33,7 +37,7 @@
 
 {% if results is not None %}
   <div class="mt-section">
-    <h2>Results for {{ results|first.growth_area.state_display|default:selected_state }}
+    <h2>Results for {% if results.0 %}{{ results.0.growth_area.state }}{% else %}{{ selected_state }}{% endif %}
         {% if emp_growth is not None %} <span class="ml-link" title="Employment growth reflects statewide data">📍 State-level employment growth</span>{% endif %}</h2>
     <p class="empty-state-body mb-4">
       {% if emp_growth is not None %}

--- a/tests/test_market_adapters.py
+++ b/tests/test_market_adapters.py
@@ -11,7 +11,10 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
-from core.integrations.market.census import fetch_zip_demographics
+from core.integrations.market.census import (
+    discover_places_in_state,
+    fetch_zip_demographics,
+)
 from core.integrations.market.bls import fetch_unemployment_rate
 
 
@@ -356,3 +359,225 @@ class RefreshMarketDataCommandTest(TestCase):
         mock_census.assert_called_once()
         snapshot = MarketSnapshot.objects.get(zip_code="90210")
         self.assertEqual(snapshot.population, 40000)
+
+
+# ===========================================================================
+#  TASK-3 — discover_places_in_state (Census place geography wildcard)
+# ===========================================================================
+
+
+class DiscoverPlacesInStateTest(TestCase):
+    """Test Census place discovery via wildcard geography query."""
+
+    def _mock_census_response(self, rows: list[list[str]]) -> MagicMock:
+        """Helper: create a mock Census API response with header + data rows."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [
+            ["B01001_001E", "NAME", "state", "place"],
+            *rows,
+        ]
+        mock_resp.raise_for_status.return_value = None
+        return mock_resp
+
+    def _make_place_row(
+        self, pop: int | str, name: str = "Test City", place_code: str = "44000"
+    ) -> list[str]:
+        """Helper: build a single Census place data row.
+
+        The NAME field follows Census format: "<place name>, <state>".
+        For legal/statistical areas Census appends " city" automatically.
+        Our helper mirrors this — the test name parameter is the "legal name"
+        and we add the suffix to match real Census output.
+        """
+        return [str(pop), f"{name}, California", "06", place_code]
+
+    # -- Happy path ---------------------------------------------------------
+
+    @patch("core.integrations.market.census.requests.get")
+    def test_returns_expected_structure(self, mock_get: MagicMock) -> None:
+        """Returns list of dicts with place_code, place_name, population."""
+        mock_get.return_value = self._mock_census_response(
+            [
+                self._make_place_row(400000, "Los Angeles", "44000"),
+                self._make_place_row(100000, "San Diego", "66000"),
+            ]
+        )
+
+        result = discover_places_in_state("CA", "test-key")
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        for entry in result:
+            self.assertIn("place_code", entry)
+            self.assertIn("place_name", entry)
+            self.assertIn("population", entry)
+            self.assertIsInstance(entry["population"], int)
+
+    @patch("core.integrations.market.census.requests.get")
+    def test_respects_limit(self, mock_get: MagicMock) -> None:
+        """Returns at most ``limit`` items even when more places exist."""
+        mock_get.return_value = self._mock_census_response(
+            [
+                self._make_place_row(500_000, "City A", "10000"),
+                self._make_place_row(400_000, "City B", "20000"),
+                self._make_place_row(300_000, "City C", "30000"),
+                self._make_place_row(200_000, "City D", "40000"),
+            ]
+        )
+
+        result = discover_places_in_state("CA", "test-key", limit=2)
+
+        self.assertEqual(len(result), 2)
+
+    @patch("core.integrations.market.census.requests.get")
+    def test_sorts_by_population_descending(self, mock_get: MagicMock) -> None:
+        """Returns places sorted by population high-to-low."""
+        mock_get.return_value = self._mock_census_response(
+            [
+                self._make_place_row(100_000, "Small City", "10000"),
+                self._make_place_row(1_000_000, "Big City", "20000"),
+                self._make_place_row(500_000, "Medium City", "30000"),
+            ]
+        )
+
+        result = discover_places_in_state("CA", "test-key")
+
+        pops = [p["population"] for p in result]
+        self.assertEqual(pops, sorted(pops, reverse=True))
+
+    @patch("core.integrations.market.census.requests.get")
+    def test_parses_place_name_without_state_suffix(self, mock_get: MagicMock) -> None:
+        """Strips trailing ', California' from NAME field."""
+        mock_get.return_value = self._mock_census_response(
+            [
+                self._make_place_row(400000, "Los Angeles city", "44000"),
+            ]
+        )
+
+        result = discover_places_in_state("CA", "test-key")
+
+        self.assertEqual(result[0]["place_name"], "Los Angeles city")
+
+    # -- Edge cases ---------------------------------------------------------
+
+    @patch("core.integrations.market.census.requests.get")
+    def test_filters_suppressed_population(self, mock_get: MagicMock) -> None:
+        """Filters rows where population is '-1' (suppressed)."""
+        mock_get.return_value = self._mock_census_response(
+            [
+                self._make_place_row(400000, "Good City", "44000"),
+                self._make_place_row("-1", "Suppressed City", "55000"),
+                self._make_place_row(300000, "Another City", "66000"),
+            ]
+        )
+
+        result = discover_places_in_state("CA", "test-key")
+
+        place_names = [p["place_name"] for p in result]
+        self.assertIn("Good City", place_names)
+        self.assertNotIn("Suppressed City", place_names)
+
+    @patch("core.integrations.market.census.requests.get")
+    def test_filters_null_population(self, mock_get: MagicMock) -> None:
+        """Filters rows where population is 'null'."""
+        mock_get.return_value = self._mock_census_response(
+            [
+                self._make_place_row(400000, "Good City", "44000"),
+                self._make_place_row("null", "Null City", "55000"),
+            ]
+        )
+
+        result = discover_places_in_state("CA", "test-key")
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["place_name"], "Good City")
+
+    @patch("core.integrations.market.census.requests.get")
+    def test_filters_blank_population(self, mock_get: MagicMock) -> None:
+        """Filters rows where population is empty string."""
+        mock_get.return_value = self._mock_census_response(
+            [
+                self._make_place_row(400000, "Good City", "44000"),
+                self._make_place_row("", "Blank City", "55000"),
+            ]
+        )
+
+        result = discover_places_in_state("CA", "test-key")
+
+        self.assertEqual(len(result), 1)
+
+    @patch("core.integrations.market.census.requests.get")
+    def test_returns_empty_list_on_http_error(self, mock_get: MagicMock) -> None:
+        """Gracefully returns empty list when HTTP request fails."""
+        import requests as req_lib
+
+        mock_get.side_effect = req_lib.ConnectionError("Connection refused")
+
+        result = discover_places_in_state("CA", "test-key")
+        self.assertEqual(result, [])
+
+    @patch("core.integrations.market.census.requests.get")
+    def test_returns_empty_list_on_invalid_json(self, mock_get: MagicMock) -> None:
+        """Gracefully returns empty list when JSON is invalid."""
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.side_effect = ValueError("Invalid JSON")
+        mock_get.return_value = mock_resp
+
+        result = discover_places_in_state("CA", "test-key")
+        self.assertEqual(result, [])
+
+    @patch("core.integrations.market.census.requests.get")
+    def test_returns_empty_list_on_empty_response(self, mock_get: MagicMock) -> None:
+        """Gracefully returns empty list when response has no data rows."""
+        mock_get.return_value = self._mock_census_response([])
+
+        result = discover_places_in_state("CA", "test-key")
+        self.assertEqual(result, [])
+
+    @patch("core.integrations.market.census.requests.get")
+    def test_returns_empty_list_on_missing_columns(self, mock_get: MagicMock) -> None:
+        """Gracefully returns empty list when expected column is missing."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [["WRONG_COL", "NAME", "state", "place"]]
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        result = discover_places_in_state("CA", "test-key")
+        self.assertEqual(result, [])
+
+    def test_returns_empty_list_on_missing_api_key(self) -> None:
+        """Returns empty list immediately when API key is empty — no HTTP call."""
+        with patch("core.integrations.market.census.requests.get") as mock_get:
+            result = discover_places_in_state("CA", "")
+            self.assertEqual(result, [])
+            mock_get.assert_not_called()
+
+    def test_returns_empty_list_on_invalid_state_code(self) -> None:
+        """Returns empty list for invalid state code — no HTTP call."""
+        with patch("core.integrations.market.census.requests.get") as mock_get:
+            result = discover_places_in_state("XX", "test-key")
+            self.assertEqual(result, [])
+            mock_get.assert_not_called()
+
+    @patch("core.integrations.market.census.requests.get")
+    def test_passes_correct_census_params(self, mock_get: MagicMock) -> None:
+        """Verifies correct Census API parameters are sent for place:* query."""
+        mock_get.return_value = self._mock_census_response(
+            [
+                self._make_place_row(400000, "Los Angeles", "44000"),
+            ]
+        )
+
+        discover_places_in_state("CA", "my-key")
+
+        mock_get.assert_called_once()
+        call_kwargs = mock_get.call_args
+        self.assertIn("api.census.gov", call_kwargs[0][0])
+        params = call_kwargs[1]["params"]
+        self.assertEqual(params["key"], "my-key")
+        self.assertEqual(params["for"], "place:*")
+        self.assertEqual(params["in"], "state:06")  # CA FIPS code
+        self.assertIn("B01001_001E", params["get"])


### PR DESCRIPTION
## Problem
TASK-7: No tests existed for TASK-3 (discover_places_in_state) or TASK-4 (growth_explorer view). These functions are core to the Growth Area Explorer feature and need test coverage before trunk merge.

## Solution
Added 14 adapter tests and 14 view tests covering all expected behaviors and edge cases. All HTTP calls mocked — no real API calls.

### discover_places_in_state tests (tests/test_market_adapters.py)
- Expected structure, limit, sort order
- Census NAME parsing, suppressed/null/blank population filtering
- HTTP errors, invalid JSON, empty response, missing columns
- Missing API key, invalid state code (no HTTP call)
- Correct Census API parameters (place:* query, state FIPS)

### Growth Explorer view tests (core/tests/test_growth_explorer.py)
- GET returns 200 with states in context
- POST error paths: empty/invalid state, missing API keys, no places found, skipped failed place
- POST creates GrowthArea rows on success
- POST updates existing GrowthArea rows
- **All places share same employment_growth_rate** (state-level BLS — documented limitation)
- Results sorted by composite_score descending
- emp_growth in template context
- housing_demand defaults to 50 when API returns None

### Template fixes (pre-existing bugs discovered during testing)
- Fixed invalid `{{ results|first.growth_area.state_display|default:selected_state }}` Django template syntax → `results.0.growth_area.state`
- Added error message display block (`<div class="message message-error">`)
- Fixed `US_STATES` → `states` (template referenced wrong context variable)
- Added `mul` math filter template tag (core/templatetags/math_filters.py)

## Validation
- `pytest tests/test_market_adapters.py::DiscoverPlacesInStateTest` — 14 passed (0 failed)
- `pytest core/tests/test_growth_explorer.py` — 14 passed (0 failed)
- `pytest core/tests/` — 635 passed (0 failed)
- Pre-commit all green (ruff, ruff-format, mypy, bandit, djLint, secrets, etc.)

## Risks
- Low. All HTTP calls mocked, no live API changes, no data model changes, no new dependencies.

## AI-Assisted Review Block
- `tests/test_market_adapters.py`: +227 lines (new DiscoverPlacesInStateTest class, 14 test methods) — reviewed for assertion correctness and edge case coverage.
- `core/tests/test_growth_explorer.py`: +425 lines (new file, 14 test methods in 3 classes) — reviewed for mock path accuracy and assertion correctness.
- `core/templatetags/math_filters.py`: +23 lines (new file, mul filter) — reviewed for Decimal safety.
- `templates/growth_explorer.html`: 4 template fixes (syntax, error display, context variable, mul filter load).