### PR TITLE
docs: add seed_data step to quick start and make dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help ensure-env dev superuser lint test check deploy-dev gitops-validate gitops-hook-install
+.PHONY: help ensure-env dev seed superuser lint test check deploy-dev gitops-validate gitops-hook-install
 
 PYTHON ?= python
 ENV_FILE ?= .env
@@ -18,7 +18,8 @@ endef
 
 help:
 	@echo "Available targets:"
-	@echo "  make dev              Run migrations and start the Django dev server"
+	@echo "  make dev              Run migrate + seed_data and start the Django dev server"
+	@echo "  make seed             Seed demo user and sample properties"
 	@echo "  make superuser        Create a Django superuser"
 	@echo "  make lint             Run Ruff and Black checks"
 	@echo "  make test             Run the test suite"
@@ -36,7 +37,12 @@ ensure-env:
 dev: ensure-env
 	$(call ensure_django)
 	@$(PYTHON) manage.py migrate
+	@$(PYTHON) manage.py seed_data
 	@$(PYTHON) manage.py runserver 0.0.0.0:8000
+
+seed: ensure-env
+	$(call ensure_django)
+	@$(PYTHON) manage.py seed_data
 
 superuser: ensure-env
 	$(call ensure_django)
@@ -65,6 +71,7 @@ deploy-dev: ensure-env
 	fi
 	@docker compose up -d
 	@docker compose exec web $(PYTHON) manage.py migrate
+	@docker compose exec web $(PYTHON) manage.py seed_data
 	@echo "Docker stack is running on port 8000"
 
 gitops-validate:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ cd prei
 cp .env.example .env
 # Edit .env — set SECRET_KEY, DJANGO_ENV=development
 docker compose up -d
+docker compose exec web python manage.py migrate
+docker compose exec web python manage.py seed_data
 # Open http://127.0.0.1:8000
 ```
 
@@ -62,9 +64,10 @@ docker compose up -d
    ```bash
    make dev
    ```
+   > `make dev` runs `migrate` and `seed_data` automatically — the demo user will be created for you.
 3. Open forwarded port 8000 → `http://localhost:8000`
 
-Demo login: `demo@prei.dev` / `DemoPass123!`
+**Demo login:** `demo@prei.dev` / `DemoPass123!`
 
 ### Deploy to Render (prod)
 


### PR DESCRIPTION
## Problem
The demo user (`demo@prei.dev` / `DemoPass123!`) doesn't exist until `python manage.py seed_data` is run, but neither the README nor `make dev` ran it. Users following the Quick Start instructions hit a login failure with no indication why.

## Changes
- **README local-dev instructions:** added `migrate` + `seed_data` steps after `docker compose up -d`
- **README devcontainer section:** noted that `make dev` auto-runs `seed_data`
- **Makefile `dev` target:** added `manage.py seed_data` after `migrate`
- **Makefile `deploy-dev` target:** added `manage.py seed_data` after `migrate`
- **New `make seed` target:** standalone `manage.py seed_data` convenience command

## Validation
- Pre-commit all green (this is docs/Makefile only — no code changes)
- `python manage.py seed_data` creates the demo user and sample properties (idempotent on re-run)

Fixes the demo login being broken on first container start.