### PR TITLE
feat(pipeline): pipe-3 - build pipeline lifecycle service

### DIFF
--- a/core/services/pipeline.py
+++ b/core/services/pipeline.py
@@ -1,0 +1,397 @@
+"""Pipeline lifecycle service for property acquisition workflow.
+
+Provides the authoritative operations for advancing, killing, holding,
+and reactivating PipelineProperty records. Also handles creation from
+source models (VRM, Foreclosure) and conversion to Property records.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Tuple
+
+from django.db import transaction
+from django.utils import timezone
+
+if TYPE_CHECKING:
+    pass
+
+
+# ── Stage order ────────────────────────────────────────────────────────────────
+
+STAGE_ORDER: list[str] = [
+    "DISCOVERED",
+    "SCREENING",
+    "UNDERWRITING",
+    "OFFER",
+    "DUE_DILIGENCE",
+    "CLOSING",
+    "ACQUIRED",
+    "RENOVATION",
+    "STABILIZED",
+]
+
+# Map stage value → timestamp field name on PipelineProperty
+STAGE_TIMESTAMP_FIELD: dict[str, str] = {
+    "DISCOVERED": "discovered_at",
+    "SCREENING": "screening_at",
+    "UNDERWRITING": "underwriting_at",
+    "OFFER": "offer_at",
+    "DUE_DILIGENCE": "due_diligence_at",
+    "CLOSING": "closing_at",
+    "ACQUIRED": "acquired_at",
+    "RENOVATION": "renovation_at",
+    "STABILIZED": "stabilized_at",
+}
+
+
+# ── Stage helpers ──────────────────────────────────────────────────────────────
+
+
+def _get_stage_index(stage: str) -> int:
+    """Get the index of a stage in STAGE_ORDER."""
+    try:
+        return STAGE_ORDER.index(stage)
+    except ValueError:
+        raise ValueError(f"Unknown stage: {stage}")
+
+
+# ── Core lifecycle operations ──────────────────────────────────────────────────
+
+
+def advance_stage(pipeline_property: Any) -> Any:
+    """Advance a PipelineProperty to the next sequential stage.
+
+    Sets the corresponding stage timestamp and saves with update_fields.
+    Raises ValueError if the property is KILLED, ON_HOLD, or at STABILIZED.
+
+    Args:
+        pipeline_property: PipelineProperty instance to advance.
+
+    Returns:
+        The same PipelineProperty instance (updated in place, caller
+        should refresh from DB if needed).
+
+    Raises:
+        ValueError: If status is KILLED or ON_HOLD, or if already at STABILIZED.
+    """
+    from core.models import PipelineProperty
+
+    if pipeline_property.status in (
+        PipelineProperty.Status.KILLED,
+        PipelineProperty.Status.ON_HOLD,
+    ):
+        raise ValueError(
+            f"Cannot advance property with status '{pipeline_property.status}'"
+        )
+
+    current_stage = pipeline_property.stage
+    current_idx = _get_stage_index(current_stage)
+
+    if current_stage == "STABILIZED":
+        raise ValueError("Cannot advance — already at final stage STABILIZED")
+
+    next_stage = STAGE_ORDER[current_idx + 1]
+    next_timestamp_field = STAGE_TIMESTAMP_FIELD[next_stage]
+
+    setattr(pipeline_property, next_timestamp_field, timezone.now())
+    pipeline_property.stage = next_stage
+
+    update_fields = ["stage", next_timestamp_field, "updated_at"]
+    pipeline_property.save(update_fields=update_fields)
+
+    return pipeline_property
+
+
+def kill_property(
+    pipeline_property: Any,
+    reason: str,
+) -> Any:
+    """Kill a PipelineProperty — sets status=KILLED and records the reason.
+
+    Args:
+        pipeline_property: PipelineProperty instance to kill.
+        reason: Human-readable reason for the kill.
+
+    Returns:
+        The same PipelineProperty instance.
+    """
+    pipeline_property.status = "KILLED"
+    pipeline_property.kill_reason = reason
+    pipeline_property.save(update_fields=["status", "kill_reason", "updated_at"])
+
+    return pipeline_property
+
+
+def hold_property(
+    pipeline_property: Any,
+    reason: str = "",
+) -> Any:
+    """Place a PipelineProperty on hold.
+
+    Sets status=ON_HOLD. The property stays at its current stage.
+
+    Args:
+        pipeline_property: PipelineProperty instance to hold.
+        reason: Optional reason for the hold.
+
+    Returns:
+        The same PipelineProperty instance.
+    """
+    pipeline_property.status = "ON_HOLD"
+    if reason:
+        pipeline_property.kill_reason = reason
+    pipeline_property.save(update_fields=["status", "kill_reason", "updated_at"])
+
+    return pipeline_property
+
+
+def reactivate_property(pipeline_property: Any) -> Any:
+    """Reactivate a KILLED or ON_HOLD property.
+
+    Sets status=ACTIVE at its current stage. Does NOT advance the stage.
+
+    Args:
+        pipeline_property: PipelineProperty instance to reactivate.
+
+    Returns:
+        The same PipelineProperty instance.
+    """
+    pipeline_property.status = "ACTIVE"
+    pipeline_property.save(update_fields=["status", "updated_at"])
+
+    return pipeline_property
+
+
+# ── Source record resolution ───────────────────────────────────────────────────
+
+
+def get_source_record(pipeline_property: Any) -> Any | None:
+    """Resolve the source model instance for a PipelineProperty.
+
+    Maps source_type to the corresponding model and looks up by source_id.
+
+    Supported source types:
+        - vrm        → VrmProperty (by vrm_property_id)
+        - foreclosure → ForeclosureProperty (by property_id)
+        - listing    → Listing (by id / pk)
+
+    Returns:
+        Model instance, or None if source_type is 'manual' or unrecognised.
+    """
+    from core.models import ForeclosureProperty, VrmProperty
+
+    source_type = pipeline_property.source_type
+    source_id = pipeline_property.source_id
+
+    if source_type == "vrm":
+        try:
+            return VrmProperty.objects.get(vrm_property_id=int(source_id))
+        except (VrmProperty.DoesNotExist, ValueError):
+            return None
+
+    if source_type == "foreclosure":
+        try:
+            return ForeclosureProperty.objects.get(property_id=source_id)
+        except ForeclosureProperty.DoesNotExist:
+            return None
+
+    if source_type == "listing":
+        from core.models import Listing
+
+        try:
+            return Listing.objects.get(pk=int(source_id))
+        except (Listing.DoesNotExist, ValueError):
+            return None
+
+    return None
+
+
+# ── Creation from source models ────────────────────────────────────────────────
+
+
+def create_from_vrm(
+    vrm_property: Any,
+    user: Any,
+) -> Tuple[Any, bool]:
+    """Create a PipelineProperty from a VrmProperty and run screening.
+
+    Denormalizes key fields from the VrmProperty, runs screen_property()
+    immediately, and sets stage=SCREENING (screening already executed).
+
+    Args:
+        vrm_property: VrmProperty instance.
+        user: Django User who owns this pipeline entry.
+
+    Returns:
+        Tuple of (PipelineProperty, created). created=False if a PP
+        already exists for this (user, vrm) combination.
+    """
+    from core.models import PipelineProperty, ScreeningCriteria
+    from core.services.screening import screen_property
+
+    criteria, _ = ScreeningCriteria.objects.get_or_create(user=user)
+
+    pp, created = PipelineProperty.objects.get_or_create(
+        user=user,
+        source_type=PipelineProperty.SourceType.VRM,
+        source_id=str(vrm_property.vrm_property_id),
+        defaults={
+            "address": vrm_property.address or "",
+            "address_hash": "",
+            "stage": PipelineProperty.Stage.DISCOVERED,
+            "status": PipelineProperty.Status.ACTIVE,
+            "price": vrm_property.list_price,
+            "estimated_rent": vrm_property.projected_monthly_rent,
+            "beds": vrm_property.bedrooms,
+            "year_built": vrm_property.year_built,
+            "discovered_at": timezone.now(),
+        },
+    )
+
+    if not created:
+        return pp, False
+
+    # Run screening immediately
+    result = screen_property(pp, criteria, source_record=vrm_property)
+
+    pp.screening_passed = result.passed
+    pp.screening_at = timezone.now()
+    pp.stage = PipelineProperty.Stage.SCREENING
+    pp.save(
+        update_fields=[
+            "screening_passed",
+            "screening_at",
+            "stage",
+            "updated_at",
+        ]
+    )
+
+    return pp, True
+
+
+def create_from_foreclosure(
+    foreclosure_property: Any,
+    user: Any,
+) -> Tuple[Any, bool]:
+    """Create a PipelineProperty from a ForeclosureProperty and run screening.
+
+    Same pattern as create_from_vrm. ForeclosureProperty has no rent data,
+    so yield/PTR screening criteria will be skipped (see screen_property).
+
+    Args:
+        foreclosure_property: ForeclosureProperty instance.
+        user: Django User who owns this pipeline entry.
+
+    Returns:
+        Tuple of (PipelineProperty, created).
+    """
+    from core.models import PipelineProperty, ScreeningCriteria
+    from core.services.screening import screen_property
+
+    criteria, _ = ScreeningCriteria.objects.get_or_create(user=user)
+
+    pp, created = PipelineProperty.objects.get_or_create(
+        user=user,
+        source_type=PipelineProperty.SourceType.FORECLOSURE,
+        source_id=foreclosure_property.property_id,
+        defaults={
+            "address": foreclosure_property.street or "",
+            "address_hash": "",
+            "stage": PipelineProperty.Stage.DISCOVERED,
+            "status": PipelineProperty.Status.ACTIVE,
+            "price": foreclosure_property.opening_bid,
+            "beds": foreclosure_property.bedrooms,
+            "year_built": foreclosure_property.year_built,
+            "discovered_at": timezone.now(),
+        },
+    )
+
+    if not created:
+        return pp, False
+
+    # Run screening immediately
+    result = screen_property(pp, criteria, source_record=foreclosure_property)
+
+    pp.screening_passed = result.passed
+    pp.screening_at = timezone.now()
+    pp.stage = PipelineProperty.Stage.SCREENING
+    pp.save(
+        update_fields=[
+            "screening_passed",
+            "screening_at",
+            "stage",
+            "updated_at",
+        ]
+    )
+
+    return pp, True
+
+
+# ── Conversion to Property record ──────────────────────────────────────────────
+
+
+def convert_to_property_record(
+    pipeline_property: Any,
+    closing_date: Any = None,
+) -> Any:
+    """Convert a PipelineProperty to a Property record (post-acquisition).
+
+    Creates a Property model instance from pipeline data, sets the FK
+    back-reference, and marks the pipeline property as ACQUIRED.
+
+    Runs within a transaction.atomic() block.
+
+    Args:
+        pipeline_property: PipelineProperty at CLOSING or ACQUIRED stage.
+        closing_date: Optional date of closing (defaults to now).
+
+    Returns:
+        The newly created Property instance.
+
+    Raises:
+        ValueError: If the pipeline property already has a property_record.
+    """
+    from core.models import Property as PropertyModel
+
+    if pipeline_property.property_record_id is not None:
+        raise ValueError(
+            "PipelineProperty already converted — "
+            f"Property record #{pipeline_property.property_record_id} exists"
+        )
+
+    now = timezone.now()
+    closing = closing_date or now
+
+    source_record = get_source_record(pipeline_property)
+
+    with transaction.atomic():
+        prop = PropertyModel.objects.create(
+            user=pipeline_property.user,
+            address=pipeline_property.address,
+            city=getattr(source_record, "city", "") or "",
+            state=getattr(source_record, "state", "") or "",
+            zip_code=getattr(source_record, "zip_code", "") or "",
+            purchase_price=pipeline_property.price or Decimal("0"),
+            purchase_date=closing if hasattr(closing, "strftime") else now,
+            bedrooms=pipeline_property.beds or 0,
+            sqft=int(pipeline_property.sqft) if pipeline_property.sqft else 0,
+            property_type="SFR",
+            monthly_rent_gross=pipeline_property.estimated_rent or Decimal("0"),
+        )
+
+        pipeline_property.property_record = prop
+        pipeline_property.status = "ACQUIRED"
+        pipeline_property.stage = "ACQUIRED"
+        pipeline_property.acquired_at = now
+        pipeline_property.save(
+            update_fields=[
+                "property_record",
+                "status",
+                "stage",
+                "acquired_at",
+                "updated_at",
+            ]
+        )
+
+    return prop

--- a/core/services/screening.py
+++ b/core/services/screening.py
@@ -1,0 +1,639 @@
+"""Screening service for pipeline property evaluation.
+
+Provides the ScreeningResult dataclass and screen_property() function
+that evaluates a PipelineProperty against a user's ScreeningCriteria.
+Handles both hard-kill (immediate reject) and soft (score-based) criteria,
+with special handling for VrmProperty (has rent data) vs ForeclosureProperty
+(no rent data) source types.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import User
+
+    from core.models import (
+        GrowthArea,
+        PipelineProperty,
+        ScreeningCriteria,
+    )
+
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+# Score deduction weights for soft criteria failures.
+# Each is the maximum points deducted when the criterion is fully violated.
+# Proportional deduction is applied — e.g. 10% below threshold = 10% of max.
+GACS_DEDUCTION_MAX = Decimal("20")  # Up to 20 pts for GACS shortfall
+YIELD_DEDUCTION_MAX = Decimal("15")  # Up to 15 pts for yield below min
+PTR_DEDUCTION_MAX = Decimal("10")  # Up to 10 pts for PTR above max
+YEAR_BUILT_DEDUCTION = Decimal("5")  # Fixed 5 pts for property too old
+BEDS_DEDUCTION_PER_UNIT = Decimal("5")  # 5 pts per bed outside range, max 10
+
+
+# ── Public dataclass ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class ScreeningResult:
+    """Result of evaluating a PipelineProperty against ScreeningCriteria.
+
+    Attributes:
+        passed:       True if no hard failures AND final score >= 50.
+        score:       Final score 0-100 (Decimal). Starts at 100, soft failures
+                     deduct proportionally.
+        hard_failures:  List of reasons that caused an immediate kill
+                        (empty if no hard failures).
+        soft_failures:  List of reasons for score deductions
+                        (non-fatal, but reduce score).
+        passes:      List of criteria that were checked and passed, or were
+                     skipped due to missing data.
+        notes:       Free-text notes about any exceptional conditions
+                     (e.g. "Yield screening skipped — no rent data").
+    """
+
+    passed: bool = True
+    score: Decimal = Decimal("100")
+    hard_failures: list[str] = field(default_factory=list)
+    soft_failures: list[str] = field(default_factory=list)
+    passes: list[str] = field(default_factory=list)
+    notes: str = ""
+
+
+def _kill_result(reason: str) -> ScreeningResult:
+    """Helper to construct a killed ScreeningResult."""
+    return ScreeningResult(
+        passed=False,
+        score=Decimal("0"),
+        hard_failures=[reason],
+    )
+
+
+def _fail_result(reason: str, score: Decimal, passes: list[str]) -> ScreeningResult:
+    """Helper for a failed result with soft failures (score < 50)."""
+    return ScreeningResult(
+        passed=False,
+        score=max(Decimal("0"), score),
+        soft_failures=[reason],
+        passes=passes,
+    )
+
+
+# ── Data extraction helpers ───────────────────────────────────────────────────
+
+
+def _extract_state(
+    pipeline_property: PipelineProperty,
+    source_record: Any | None,
+) -> str | None:
+    """Extract state from source_record, or None."""
+    if source_record is not None:
+        return getattr(source_record, "state", None)
+    return None
+
+
+def _extract_city(
+    pipeline_property: PipelineProperty,
+    source_record: Any | None,
+) -> str | None:
+    """Extract city from source_record, or None."""
+    if source_record is not None:
+        return getattr(source_record, "city", None)
+    return None
+
+
+def _extract_foreclosure_status(
+    source_record: Any | None,
+) -> str | None:
+    """Extract foreclosure_status from source_record if it has one."""
+    if source_record is not None:
+        return getattr(source_record, "foreclosure_status", None)
+    return None
+
+
+def _extract_property_type(
+    source_record: Any | None,
+) -> str | None:
+    """Extract property_type from source_record if it has one."""
+    if source_record is not None:
+        return getattr(source_record, "property_type", None) or None
+    return None
+
+
+def _is_vrm_source(source_record: Any | None) -> bool:
+    """Check if source_record is a VrmProperty (has rent data)."""
+    if source_record is None:
+        return False
+    return source_record.__class__.__name__ == "VrmProperty" or hasattr(
+        source_record, "projected_monthly_rent"
+    )
+
+
+# ── Soft criterion evaluators ─────────────────────────────────────────────────
+
+
+def _eval_gacs_score(
+    pipeline_property: PipelineProperty,
+    criteria: ScreeningCriteria,
+    state: str | None,
+    city: str | None,
+) -> tuple[Decimal, Optional[str], Optional[str]]:
+    """Evaluate GACS score soft criterion.
+
+    Looks up GrowthArea by (state, city). If found and the property's
+    market score is below the user's minimum, deducts proportionally.
+
+    Returns:
+        Tuple of (deduction, pass_msg, fail_msg).
+        pass_msg is set if the criterion was skipped or passed.
+        fail_msg is set if there was a deduction.
+    """
+    if criteria.min_gacs_score is None:
+        return Decimal("0"), "GACS score screening skipped — no minimum set", None
+
+    if not state or not city:
+        return (
+            Decimal("0"),
+            "GACS score screening skipped — no state/city data available",
+            None,
+        )
+
+    try:
+        from core.models import GrowthArea
+
+        growth_area: GrowthArea | None = GrowthArea.objects.filter(
+            state=state, city_name__iexact=city
+        ).first()
+    except Exception:
+        growth_area = None
+
+    if growth_area is None or growth_area.composite_score is None:
+        return (
+            Decimal("0"),
+            f"GACS score screening skipped — no GrowthArea found for {city}, {state}",
+            None,
+        )
+
+    actual = growth_area.composite_score
+    minimum = criteria.min_gacs_score
+
+    if actual >= minimum:
+        return (
+            Decimal("0"),
+            f"GACS score {actual} >= {minimum} (min)",
+            None,
+        )
+
+    # Proportional deduction: shortfall relative to minimum
+    if minimum > 0:
+        shortfall_pct = (minimum - actual) / minimum
+    else:
+        shortfall_pct = Decimal("1")
+    deduction = (GACS_DEDUCTION_MAX * shortfall_pct).quantize(Decimal("0.01"))
+    deduction = min(deduction, GACS_DEDUCTION_MAX)
+
+    return (
+        deduction,
+        None,
+        f"GACS score {actual} below minimum {minimum} — deduct {deduction} pts",
+    )
+
+
+def _eval_gross_yield(
+    pipeline_property: PipelineProperty,
+    criteria: ScreeningCriteria,
+    source_record: Any | None,
+) -> tuple[Decimal, Optional[str], Optional[str]]:
+    """Evaluate gross yield soft criterion.
+
+    Formula: gross_yield_pct = (annual_rent / price) * 100
+    Uses projected_monthly_rent from VrmProperty or estimated_rent from
+    PipelineProperty.
+
+    Returns:
+        Tuple of (deduction, pass_msg, fail_msg).
+    """
+    if criteria.min_gross_yield_pct is None:
+        return Decimal("0"), "Gross yield screening skipped — no minimum set", None
+
+    # Determine if we have rent data
+    monthly_rent = _get_monthly_rent(pipeline_property, source_record)
+
+    if monthly_rent is None or monthly_rent <= 0:
+        return (
+            Decimal("0"),
+            "Gross yield screening skipped — no rent estimate available",
+            None,
+        )
+
+    price = pipeline_property.price
+    if price is None or price <= 0:
+        return Decimal("0"), "Gross yield screening skipped — no price available", None
+
+    annual_rent = monthly_rent * Decimal("12")
+    gross_yield_pct = (annual_rent / price) * Decimal("100")
+    minimum_pct = criteria.min_gross_yield_pct
+
+    if gross_yield_pct >= minimum_pct:
+        return (
+            Decimal("0"),
+            f"Gross yield {gross_yield_pct:.2f}% >= {minimum_pct}% (min)",
+            None,
+        )
+
+    # Proportional deduction
+    if minimum_pct > 0:
+        shortfall_pct = (minimum_pct - gross_yield_pct) / minimum_pct
+    else:
+        shortfall_pct = Decimal("1")
+    deduction = (YIELD_DEDUCTION_MAX * shortfall_pct).quantize(Decimal("0.01"))
+    deduction = min(deduction, YIELD_DEDUCTION_MAX)
+
+    return (
+        deduction,
+        None,
+        f"Gross yield {gross_yield_pct:.2f}% below minimum {minimum_pct}%"
+        f" — deduct {deduction} pts",
+    )
+
+
+def _eval_price_to_rent_ratio(
+    pipeline_property: PipelineProperty,
+    criteria: ScreeningCriteria,
+    source_record: Any | None,
+) -> tuple[Decimal, Optional[str], Optional[str]]:
+    """Evaluate price-to-rent ratio soft criterion.
+
+    Formula: ptr = price / monthly_rent
+
+    Returns:
+        Tuple of (deduction, pass_msg, fail_msg).
+    """
+    if criteria.max_price_to_rent_ratio is None:
+        return (
+            Decimal("0"),
+            "Price-to-rent ratio screening skipped — no max set",
+            None,
+        )
+
+    monthly_rent = _get_monthly_rent(pipeline_property, source_record)
+
+    if monthly_rent is None or monthly_rent <= 0:
+        return (
+            Decimal("0"),
+            "Price-to-rent ratio screening skipped — no rent estimate available",
+            None,
+        )
+
+    price = pipeline_property.price
+    if price is None or price <= 0:
+        return (
+            Decimal("0"),
+            "Price-to-rent ratio screening skipped — no price available",
+            None,
+        )
+
+    ptr = price / monthly_rent
+    max_ratio = criteria.max_price_to_rent_ratio
+
+    if ptr <= max_ratio:
+        return (
+            Decimal("0"),
+            f"Price-to-rent ratio {ptr:.2f} <= {max_ratio} (max)",
+            None,
+        )
+
+    # Proportional deduction: how much we exceed the max ratio
+    if max_ratio > 0:
+        excess_pct = (ptr - max_ratio) / max_ratio
+    else:
+        excess_pct = Decimal("1")
+    deduction = (PTR_DEDUCTION_MAX * excess_pct).quantize(Decimal("0.01"))
+    deduction = min(deduction, PTR_DEDUCTION_MAX)
+
+    return (
+        deduction,
+        None,
+        f"Price-to-rent ratio {ptr:.2f} above maximum {max_ratio}"
+        f" — deduct {deduction} pts",
+    )
+
+
+def _get_monthly_rent(
+    pipeline_property: PipelineProperty,
+    source_record: Any | None,
+) -> Decimal | None:
+    """Get monthly rent from source_record or PipelineProperty.
+
+    Prefers source_record (VrmProperty.projected_monthly_rent) over
+    PipelineProperty.estimated_rent. Returns None if neither available.
+    """
+    if (
+        source_record is not None
+        and _is_vrm_source(source_record)
+        and hasattr(source_record, "projected_monthly_rent")
+    ):
+        rent = source_record.projected_monthly_rent  # type: ignore[union-attr]
+        if rent is not None and rent > 0:
+            return Decimal(str(rent))
+
+    if (
+        pipeline_property.estimated_rent is not None
+        and pipeline_property.estimated_rent > 0
+    ):
+        return Decimal(str(pipeline_property.estimated_rent))
+
+    return None
+
+
+def _eval_year_built(
+    pipeline_property: PipelineProperty,
+    criteria: ScreeningCriteria,
+) -> tuple[Decimal, Optional[str], Optional[str]]:
+    """Evaluate year-built soft criterion.
+
+    If the property was built before max_year_built, deducts fixed points.
+
+    Returns:
+        Tuple of (deduction, pass_msg, fail_msg).
+    """
+    if criteria.max_year_built is None:
+        return Decimal("0"), "Year-built screening skipped — no max set", None
+
+    year_built = pipeline_property.year_built
+    if year_built is None:
+        return (
+            Decimal("0"),
+            "Year-built screening skipped — no year_built data available",
+            None,
+        )
+
+    if year_built >= criteria.max_year_built:
+        return (
+            Decimal("0"),
+            f"Year built {year_built} >= {criteria.max_year_built} (max cutoff)",
+            None,
+        )
+
+    return (
+        YEAR_BUILT_DEDUCTION,
+        None,
+        f"Year built {year_built} older than cutoff {criteria.max_year_built}"
+        f" — deduct {YEAR_BUILT_DEDUCTION} pts",
+    )
+
+
+def _eval_beds(
+    pipeline_property: PipelineProperty,
+    criteria: ScreeningCriteria,
+) -> tuple[Decimal, Optional[str], Optional[str]]:
+    """Evaluate beds soft criterion.
+
+    Checks min_beds and max_beds. Each bed outside range deducts
+    BEDS_DEDUCTION_PER_UNIT, capped at 10 points.
+
+    Returns:
+        Tuple of (deduction, pass_msg, fail_msg).
+    """
+    beds = pipeline_property.beds
+    if beds is None:
+        return Decimal("0"), "Beds screening skipped — no beds data available", None
+
+    deduction = Decimal("0")
+
+    if criteria.min_beds is not None and beds < criteria.min_beds:
+        shortfall = criteria.min_beds - beds
+        bed_deduction = min(
+            BEDS_DEDUCTION_PER_UNIT * Decimal(str(shortfall)),
+            Decimal("10"),
+        )
+        deduction += bed_deduction
+        fail = (
+            f"Beds {beds} below minimum {criteria.min_beds}"
+            f" — deduct {bed_deduction} pts"
+        )
+        return deduction, None, fail
+
+    if criteria.max_beds is not None and beds > criteria.max_beds:
+        excess = beds - criteria.max_beds
+        bed_deduction = min(
+            BEDS_DEDUCTION_PER_UNIT * Decimal(str(excess)),
+            Decimal("10"),
+        )
+        deduction += bed_deduction
+        fail = (
+            f"Beds {beds} above maximum {criteria.max_beds}"
+            f" — deduct {bed_deduction} pts"
+        )
+        return deduction, None, fail
+
+    bounds = f"in [{criteria.min_beds}"
+    bounds += f", {criteria.max_beds}]" if criteria.max_beds is not None else ", ∞]"
+    return Decimal("0"), f"Beds {beds} {bounds} (within range)", None
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+
+def get_or_create_criteria(user: User) -> Any:
+    """Get or create ScreeningCriteria for a user.
+
+    Args:
+        user: Django User model instance.
+
+    Returns:
+        ScreeningCriteria instance for the given user.
+    """
+    from core.models import ScreeningCriteria as ScreeningCriteriaModel
+
+    criteria, _ = ScreeningCriteriaModel.objects.get_or_create(user=user)
+    return criteria
+
+
+def screen_property(
+    pipeline_property: PipelineProperty,
+    criteria: ScreeningCriteria,
+    source_record: Any | None = None,
+) -> ScreeningResult:
+    """Evaluate a PipelineProperty against ScreeningCriteria.
+
+    Hard criteria (evaluated first, immediate kill on any failure):
+      1. State filter
+      2. Property type filter
+      3. Price range
+      4. Foreclosure status filter
+
+    Soft criteria (reduce score from 100, do not kill individually):
+      5. GACS score (GrowthArea lookup by state+city)
+      6. Gross yield (needs rent data — VrmProperty only)
+      7. Price-to-rent ratio (needs rent data — VrmProperty only)
+      8. Year built
+      9. Beds
+
+    Special handling:
+      - If source_record is a ForeclosureProperty or None, criteria 6 and 7
+        are skipped because no rent estimate is available.
+      - Missing fields on PP or source_record → skip criterion,
+        add 'SKIPPED: {criterion} — no data' to passes list.
+
+    Args:
+        pipeline_property: PipelineProperty instance being evaluated.
+        criteria:          ScreeningCriteria with user's thresholds.
+        source_record:     Optional source model instance (VrmProperty,
+                          ForeclosureProperty, etc.) for additional data.
+
+    Returns:
+        ScreeningResult with pass/fail, final score, and diagnostic lists.
+    """
+    passes: list[str] = []
+    notes: list[str] = []
+
+    # ── Extract data ──────────────────────────────────────────────────────
+    state = _extract_state(pipeline_property, source_record)
+    city = _extract_city(pipeline_property, source_record)
+    foreclosure_status = _extract_foreclosure_status(source_record)
+    property_type = _extract_property_type(source_record)
+    has_rent_data = _is_vrm_source(source_record) or (
+        pipeline_property.estimated_rent is not None
+        and pipeline_property.estimated_rent > 0
+    )
+
+    if not has_rent_data and source_record is not None:
+        notes.append(
+            "Yield and PTR screening skipped — no rent estimate available "
+            "for this source type (confirmed: no Rentcast integration)"
+        )
+
+    # ═══════════════════════════════════════════════════════════════════════
+    # HARD KILL CRITERIA — evaluated in order, return immediately on failure
+    # ═══════════════════════════════════════════════════════════════════════
+
+    # 1. State filter
+    if criteria.allowed_states:
+        if not state:
+            return _kill_result(
+                "State filter enabled but property has no state data — KILLED"
+            )
+        if state not in criteria.allowed_states:
+            return _kill_result(
+                f"State '{state}' not in allowed states: "
+                f"{', '.join(criteria.allowed_states)}"
+            )
+    passes.append(f"State '{state}' is allowed")
+
+    # 2. Property type filter
+    if criteria.allowed_property_types:
+        pt = property_type
+        if pt and pt not in criteria.allowed_property_types:
+            return _kill_result(
+                f"Property type '{pt}' not in allowed types: "
+                f"{', '.join(criteria.allowed_property_types)}"
+            )
+        if not pt:
+            passes.append(
+                "SKIPPED: Property type check — no property_type data available"
+            )
+        else:
+            passes.append(f"Property type '{pt}' is allowed")
+
+    # 3. Price range
+    price = pipeline_property.price
+    if price is not None:
+        if criteria.max_price is not None and price > criteria.max_price:
+            return _kill_result(
+                f"Price ${price:,.2f} exceeds max ${criteria.max_price:,.2f}"
+            )
+        if criteria.min_price is not None and price < criteria.min_price:
+            return _kill_result(
+                f"Price ${price:,.2f} below min ${criteria.min_price:,.2f}"
+            )
+        passes.append(
+            f"Price ${price:,.2f} within range"
+            f" [{criteria.min_price or 0}, {criteria.max_price or '∞'}]"
+        )
+    else:
+        passes.append("SKIPPED: Price range check — no price data available")
+
+    # 4. Foreclosure status filter
+    if criteria.allowed_foreclosure_statuses:
+        if not foreclosure_status:
+            passes.append(
+                "SKIPPED: Foreclosure status check — "
+                "no foreclosure_status data available"
+            )
+        elif foreclosure_status not in criteria.allowed_foreclosure_statuses:
+            return _kill_result(
+                f"Foreclosure status '{foreclosure_status}' not in allowed: "
+                f"{', '.join(criteria.allowed_foreclosure_statuses)}"
+            )
+        else:
+            passes.append(f"Foreclosure status '{foreclosure_status}' is allowed")
+
+    # ═══════════════════════════════════════════════════════════════════════
+    # SOFT CRITERIA — each deducts from score, none kills individually
+    # ═══════════════════════════════════════════════════════════════════════
+
+    score = Decimal("100")
+    soft_failures: list[str] = []
+
+    # 5. GACS score
+    ded, pass_msg, fail_msg = _eval_gacs_score(pipeline_property, criteria, state, city)
+    score -= ded
+    if pass_msg:
+        passes.append(pass_msg)
+    if fail_msg:
+        soft_failures.append(fail_msg)
+
+    # 6. Gross yield
+    ded, pass_msg, fail_msg = _eval_gross_yield(
+        pipeline_property, criteria, source_record
+    )
+    score -= ded
+    if pass_msg:
+        passes.append(pass_msg)
+    if fail_msg:
+        soft_failures.append(fail_msg)
+
+    # 7. Price-to-rent ratio
+    ded, pass_msg, fail_msg = _eval_price_to_rent_ratio(
+        pipeline_property, criteria, source_record
+    )
+    score -= ded
+    if pass_msg:
+        passes.append(pass_msg)
+    if fail_msg:
+        soft_failures.append(fail_msg)
+
+    # 8. Year built
+    ded, pass_msg, fail_msg = _eval_year_built(pipeline_property, criteria)
+    score -= ded
+    if pass_msg:
+        passes.append(pass_msg)
+    if fail_msg:
+        soft_failures.append(fail_msg)
+
+    # 9. Beds
+    ded, pass_msg, fail_msg = _eval_beds(pipeline_property, criteria)
+    score -= ded
+    if pass_msg:
+        passes.append(pass_msg)
+    if fail_msg:
+        soft_failures.append(fail_msg)
+
+    # ── Finalize ──────────────────────────────────────────────────────────
+    score = max(Decimal("0"), score.quantize(Decimal("0.01")))
+
+    passed = len(soft_failures) == 0 or score >= Decimal("50")
+
+    return ScreeningResult(
+        passed=passed,
+        score=score,
+        hard_failures=[],
+        soft_failures=soft_failures,
+        passes=passes,
+        notes="; ".join(notes) if notes else "",
+    )

--- a/tests/test_pipeline_service.py
+++ b/tests/test_pipeline_service.py
@@ -1,0 +1,485 @@
+"""Unit tests for core/services/pipeline.py pipeline service.
+
+Tests cover: advance_stage, kill_property, hold_property, reactivate_property,
+get_source_record, create_from_vrm, create_from_foreclosure, duplicate
+prevention, convert_to_property_record, atomic rollback.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from core.services.pipeline import (
+    STAGE_ORDER,
+    advance_stage,
+    convert_to_property_record,
+    create_from_foreclosure,
+    create_from_vrm,
+    get_source_record,
+    hold_property,
+    kill_property,
+    reactivate_property,
+)
+
+User = get_user_model()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  Fixtures
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="pipe",
+        email="pipe@test.com",
+        password="testpass123",
+    )
+
+
+@pytest.fixture
+def vrm_property(db):
+    """VrmProperty fixture for create_from_vrm tests."""
+    from core.models import VrmProperty as VP
+
+    now = timezone.now()
+    vp = VP(
+        vrm_property_id=1001,
+        vrm_listing_url="https://example.com/1001",
+        address="1001 Pipeline Ave",
+        city="Austin",
+        state="TX",
+        zip_code="78701",
+        list_price=Decimal("250000"),
+        projected_monthly_rent=Decimal("2000"),
+        bedrooms=3,
+        year_built=2010,
+        property_type="single-family",
+        status=VP.Status.FOR_SALE,
+        scraped_at=now,
+        last_seen_at=now,
+    )
+    vp.save()
+    return vp
+
+
+@pytest.fixture
+def foreclosure_property(db):
+    """ForeclosureProperty fixture for create_from_foreclosure tests."""
+    from core.models import ForeclosureProperty
+
+    fp = ForeclosureProperty(
+        property_id="fc-pipe-001",
+        data_source="county",
+        data_timestamp="2026-01-01 00:00:00+00",
+        street="2002 Foreclosure Ln",
+        city="Dallas",
+        state="TX",
+        zip_code="75201",
+        foreclosure_status="auction",
+        property_type="single-family",
+        opening_bid=Decimal("180000"),
+        bedrooms=3,
+        year_built=2005,
+        square_footage=1500,
+    )
+    fp.save()
+    return fp
+
+
+@pytest.fixture
+def pp_base(db, user):
+    """Basic PipelineProperty starting at DISCOVERED."""
+    from core.models import PipelineProperty
+
+    pp = PipelineProperty(
+        user=user,
+        source_type="manual",
+        source_id="pipe-test-001",
+        address="300 Test Blvd",
+        address_hash="test-hash",
+        stage=PipelineProperty.Stage.DISCOVERED,
+        status=PipelineProperty.Status.ACTIVE,
+        price=Decimal("200000"),
+        estimated_rent=Decimal("1800"),
+        beds=3,
+        year_built=2008,
+        discovered_at=timezone.now(),
+    )
+    pp.save()
+    return pp
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  STAGE_ORDER
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestStageOrder:
+    def test_has_nine_stages(self):
+        """STAGE_ORDER has exactly 9 stages matching PipelineProperty.Stage."""
+        assert len(STAGE_ORDER) == 9
+
+    def test_first_is_discovered(self):
+        assert STAGE_ORDER[0] == "DISCOVERED"
+
+    def test_last_is_stabilized(self):
+        assert STAGE_ORDER[-1] == "STABILIZED"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  advance_stage
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestAdvanceStage:
+    def test_advances_to_next_stage(self, pp_base):
+        """DISCOVERED → SCREENING."""
+        result = advance_stage(pp_base)
+        assert result.stage == "SCREENING"
+        assert result.screening_at is not None
+
+    def test_sets_timestamp(self, pp_base):
+        """Each advance sets the corresponding stage timestamp."""
+        advance_stage(pp_base)
+        assert pp_base.screening_at is not None
+        assert pp_base.discovered_at is not None  # was set in fixture
+
+    def test_advances_through_multiple_stages(self, pp_base):
+        """Advancing multiple times moves through the stage order."""
+        stages = ["SCREENING", "UNDERWRITING", "OFFER", "DUE_DILIGENCE"]
+        for expected in stages:
+            result = advance_stage(pp_base)
+            assert result.stage == expected
+
+    def test_raises_on_killed(self, pp_base):
+        """Killed properties cannot advance."""
+        kill_property(pp_base, "Not interested")
+        with pytest.raises(ValueError, match="Cannot advance"):
+            advance_stage(pp_base)
+
+    def test_raises_on_on_hold(self, pp_base):
+        """ON_HOLD properties cannot advance."""
+        hold_property(pp_base, "Waiting on inspection")
+        with pytest.raises(ValueError, match="Cannot advance"):
+            advance_stage(pp_base)
+
+    def test_raises_at_stabilized(self, pp_base):
+        """Already at STABILIZED raises ValueError."""
+        pp_base.stage = "STABILIZED"
+        pp_base.save()
+        with pytest.raises(ValueError, match="already at final stage"):
+            advance_stage(pp_base)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  kill_property
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestKillProperty:
+    def test_kills_property(self, pp_base):
+        """Sets status=KILLED and records reason."""
+        result = kill_property(pp_base, "Below yield threshold")
+        assert result.status == "KILLED"
+        assert result.kill_reason == "Below yield threshold"
+
+    def test_kill_does_not_change_stage(self, pp_base):
+        """Stage stays current; only status changes."""
+        current = pp_base.stage
+        kill_property(pp_base, "test")
+        assert pp_base.stage == current
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  hold_property
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestHoldProperty:
+    def test_sets_on_hold(self, pp_base):
+        """Sets status=ON_HOLD."""
+        result = hold_property(pp_base, "Awaiting appraisal")
+        assert result.status == "ON_HOLD"
+
+    def test_hold_records_reason(self, pp_base):
+        hold_property(pp_base, "Need more data")
+        assert pp_base.kill_reason == "Need more data"
+
+    def test_hold_without_reason(self, pp_base):
+        hold_property(pp_base)
+        assert pp_base.status == "ON_HOLD"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  reactivate_property
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestReactivateProperty:
+    def test_reactivates_killed(self, pp_base):
+        """KILLED → ACTIVE at same stage."""
+        kill_property(pp_base, "Rejected")
+        result = reactivate_property(pp_base)
+        assert result.status == "ACTIVE"
+
+    def test_reactivates_on_hold(self, pp_base):
+        """ON_HOLD → ACTIVE at same stage."""
+        hold_property(pp_base)
+        result = reactivate_property(pp_base)
+        assert result.status == "ACTIVE"
+
+    def test_reactivate_does_not_change_stage(self, pp_base):
+        """Stage unchanged after reactivation."""
+        advance_stage(pp_base)  # → SCREENING
+        hold_property(pp_base)
+        reactivate_property(pp_base)
+        assert pp_base.stage == "SCREENING"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  get_source_record
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGetSourceRecord:
+    def test_resolves_vrm(self, db, user, vrm_property):
+        """source_type='vrm' resolves to VrmProperty."""
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="vrm",
+            source_id="1001",
+            address="test",
+            address_hash="h",
+        )
+        pp.save()
+
+        record = get_source_record(pp)
+        assert record is not None
+        assert record.vrm_property_id == 1001
+
+    def test_resolves_foreclosure(self, db, user, foreclosure_property):
+        """source_type='foreclosure' resolves to ForeclosureProperty."""
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="foreclosure",
+            source_id="fc-pipe-001",
+            address="test",
+            address_hash="h",
+        )
+        pp.save()
+
+        record = get_source_record(pp)
+        assert record is not None
+        assert record.property_id == "fc-pipe-001"
+
+    def test_returns_none_for_manual(self, db, user):
+        """source_type='manual' returns None."""
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="manual",
+            source_id="m-001",
+            address="test",
+            address_hash="h",
+        )
+        pp.save()
+
+        assert get_source_record(pp) is None
+
+    def test_returns_none_for_unknown_type(self, db, user):
+        """Unknown source_type returns None."""
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="bogus",
+            source_id="x",
+            address="test",
+            address_hash="h",
+        )
+        pp.save()
+
+        assert get_source_record(pp) is None
+
+    def test_returns_none_for_missing_id(self, db, user):
+        """Nonexistent source_id returns None."""
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="vrm",
+            source_id="999999",
+            address="test",
+            address_hash="h",
+        )
+        pp.save()
+
+        assert get_source_record(pp) is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  create_from_vrm
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCreateFromVrm:
+    def test_creates_pipeline_property(self, db, user, vrm_property):
+        """Creates PipelineProperty with denormalized fields."""
+        pp, created = create_from_vrm(vrm_property, user)
+        assert created
+        assert pp.source_type == "vrm"
+        assert pp.source_id == "1001"
+        assert pp.price == vrm_property.list_price
+        assert pp.estimated_rent == vrm_property.projected_monthly_rent
+        assert pp.beds == vrm_property.bedrooms
+
+    def test_advances_to_screening(self, db, user, vrm_property):
+        """PP created with stage=SCREENING (screening already ran)."""
+        pp, created = create_from_vrm(vrm_property, user)
+        assert pp.stage == "SCREENING"
+        assert pp.screening_at is not None
+
+    def test_screening_result_stored(self, db, user, vrm_property):
+        """screening_passed is set from screen_property result."""
+        pp, created = create_from_vrm(vrm_property, user)
+        assert created
+        # screening_passed will be True or False depending on defaults
+        assert pp.screening_passed is not None
+
+    def test_duplicate_returns_false(self, db, user, vrm_property):
+        """Second call with same VrmProperty returns created=False."""
+        pp1, created1 = create_from_vrm(vrm_property, user)
+        pp2, created2 = create_from_vrm(vrm_property, user)
+        assert created1
+        assert not created2
+        assert pp1.pk == pp2.pk
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  create_from_foreclosure
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCreateFromForeclosure:
+    def test_creates_pipeline_property(self, db, user, foreclosure_property):
+        """Creates PipelineProperty with denormalized fields."""
+        pp, created = create_from_foreclosure(foreclosure_property, user)
+        assert created
+        assert pp.source_type == "foreclosure"
+        assert pp.source_id == "fc-pipe-001"
+        assert pp.price == foreclosure_property.opening_bid
+        assert pp.beds == foreclosure_property.bedrooms
+
+    def test_advances_to_screening(self, db, user, foreclosure_property):
+        """PP created with stage=SCREENING."""
+        pp, created = create_from_foreclosure(foreclosure_property, user)
+        assert pp.stage == "SCREENING"
+        assert pp.screening_at is not None
+
+    def test_screening_result_stored(self, db, user, foreclosure_property):
+        """screening_passed is set (yield/PTR skipped for foreclosure)."""
+        pp, created = create_from_foreclosure(foreclosure_property, user)
+        assert created
+        assert pp.screening_passed is not None
+
+    def test_duplicate_returns_false(self, db, user, foreclosure_property):
+        """Second call returns created=False."""
+        pp1, created1 = create_from_foreclosure(foreclosure_property, user)
+        pp2, created2 = create_from_foreclosure(foreclosure_property, user)
+        assert created1
+        assert not created2
+        assert pp1.pk == pp2.pk
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  convert_to_property_record
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestConvertToPropertyRecord:
+    def test_creates_property_record(self, db, user, vrm_property):
+        """Creates Property with denormalized pipeline data."""
+        pp, _ = create_from_vrm(vrm_property, user)
+
+        # Advance to CLOSING first (realistic flow)
+        # create_from_vrm sets SCREENING, so we need 5 more advances
+        for _ in range(5):
+            advance_stage(pp)
+
+        assert pp.stage == "ACQUIRED"
+
+        prop = convert_to_property_record(pp)
+
+        assert prop is not None
+        assert prop.user == user
+        assert prop.purchase_price == Decimal("250000")
+        assert prop.monthly_rent_gross == Decimal("2000")
+
+    def test_links_back_to_pipeline(self, db, user, vrm_property):
+        """PipelineProperty.property_record set after conversion."""
+        pp, _ = create_from_vrm(vrm_property, user)
+        for _ in range(5):
+            advance_stage(pp)
+
+        convert_to_property_record(pp)
+
+        pp.refresh_from_db()
+        assert pp.property_record is not None
+        assert pp.status == "ACQUIRED"
+        assert pp.stage == "ACQUIRED"
+        assert pp.acquired_at is not None
+
+    def test_raises_on_duplicate_conversion(self, db, user, vrm_property):
+        """Second conversion attempt raises ValueError."""
+        pp, _ = create_from_vrm(vrm_property, user)
+        for _ in range(5):
+            advance_stage(pp)
+
+        convert_to_property_record(pp)
+
+        with pytest.raises(ValueError, match="already converted"):
+            convert_to_property_record(pp)
+
+    def test_atomic_rollback_on_failure(self, db, user, vrm_property):
+        """If conversion fails partway, no Property is created."""
+        from unittest.mock import patch
+
+        pp, _ = create_from_vrm(vrm_property, user)
+        for _ in range(5):
+            advance_stage(pp)
+
+        # Mock Property.create to fail after pipeline updates
+        with patch(
+            "core.models.Property.objects.create",
+            side_effect=RuntimeError("DB failure"),
+        ):
+            with pytest.raises(RuntimeError):
+                convert_to_property_record(pp)
+
+        # PipelineProperty should NOT be marked ACQUIRED
+        pp.refresh_from_db()
+        assert pp.status != "ACQUIRED"
+        assert pp.property_record is None
+
+    def test_accepts_custom_closing_date(self, db, user, vrm_property):
+        """Custom closing_date passed through."""
+        import datetime
+
+        pp, _ = create_from_vrm(vrm_property, user)
+        for _ in range(5):
+            advance_stage(pp)
+
+        closing = datetime.date(2026, 7, 15)
+        prop = convert_to_property_record(pp, closing)
+        assert prop.purchase_date == closing

--- a/tests/test_screening.py
+++ b/tests/test_screening.py
@@ -1,0 +1,857 @@
+"""Unit tests for core/services/screening.py screening service.
+
+Tests cover:
+- Hard kill criteria (state, property type, price range, foreclosure status)
+- Soft criteria (GACS score, gross yield, PTR, year built, beds)
+- VrmProperty source (yield/PTR evaluated)
+- ForeclosureProperty source (yield/PTR skipped)
+- Missing data handling
+- All pass scenario
+- No criteria set (defaults)
+- get_or_create_criteria helper
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from core.services.screening import get_or_create_criteria, screen_property
+
+User = get_user_model()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  Fixtures
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="screener",
+        email="screener@test.com",
+        password="testpass123",
+    )
+
+
+@pytest.fixture
+def criteria(db, user):
+    """ScreeningCriteria with all fields at defaults via get_or_create."""
+    return get_or_create_criteria(user)
+
+
+@pytest.fixture
+def configured_criteria(db, user):
+    """ScreeningCriteria with specific thresholds set."""
+    from core.models import ScreeningCriteria
+
+    c, _ = ScreeningCriteria.objects.get_or_create(user=user)
+    c.allowed_states = ["TX", "FL"]
+    c.allowed_property_types = ["single-family", "condo"]
+    c.min_price = Decimal("100000")
+    c.max_price = Decimal("500000")
+    c.allowed_foreclosure_statuses = ["auction", "reo"]
+    c.min_gacs_score = Decimal("50")
+    c.min_gross_yield_pct = Decimal("7.00")
+    c.max_price_to_rent_ratio = Decimal("15.00")
+    c.max_year_built = 2000
+    c.min_beds = 2
+    c.max_beds = 5
+    c.save()
+    return c
+
+
+@pytest.fixture
+def pipeline_property_base(db, user):
+    """Basic PipelineProperty (not saved) with default values that pass."""
+    from core.models import PipelineProperty
+
+    pp = PipelineProperty(
+        user=user,
+        source_type="foreclosure",
+        source_id="fc-001",
+        address="123 Main St, Austin, TX 78701",
+        address_hash="abc123",
+        stage=PipelineProperty.Stage.DISCOVERED,
+        status=PipelineProperty.Status.ACTIVE,
+        price=Decimal("250000"),
+        estimated_rent=Decimal("2000"),
+        beds=3,
+        year_built=2010,
+    )
+    pp.save()
+    return pp
+
+
+@pytest.fixture
+def vrm_property(db):
+    """VrmProperty with full data including rent."""
+    from django.utils import timezone
+    from core.models import VrmProperty as VP
+
+    now = timezone.now()
+    vp = VP(
+        vrm_property_id=999,
+        vrm_listing_url="https://example.com/listing/999",
+        address="456 Oak Ave",
+        city="Austin",
+        state="TX",
+        zip_code="78701",
+        list_price=Decimal("250000"),
+        projected_monthly_rent=Decimal("2200"),
+        bedrooms=3,
+        year_built=2015,
+        property_type="single-family",
+        status=VP.Status.FOR_SALE,
+        scraped_at=now,
+        last_seen_at=now,
+    )
+    vp.save()
+    return vp
+
+
+@pytest.fixture
+def foreclosure_property(db):
+    """ForeclosureProperty (no rent data)."""
+    from core.models import ForeclosureProperty
+
+    fp = ForeclosureProperty(
+        property_id="fc-prop-001",
+        data_source="county",
+        data_timestamp="2026-01-01 00:00:00+00",
+        street="789 Elm St",
+        city="Dallas",
+        state="TX",
+        zip_code="75201",
+        foreclosure_status="auction",
+        property_type="single-family",
+        opening_bid=Decimal("200000"),
+        bedrooms=3,
+        year_built=2005,
+        square_footage=1800,
+    )
+    fp.save()
+    return fp
+
+
+@pytest.fixture
+def growth_area(db):
+    """GrowthArea for GACS score lookup."""
+    from core.models import GrowthArea
+
+    ga = GrowthArea(
+        state="TX",
+        city_name="Austin",
+        metro_area="Austin-Round Rock",
+        population_growth_rate=Decimal("2.50"),
+        employment_growth_rate=Decimal("3.20"),
+        median_income_growth=Decimal("2.80"),
+        housing_demand_index=85,
+        supply_constraint_index=60,
+        data_timestamp="2026-01-01 00:00:00+00",
+    )
+    ga.save()
+    return ga
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  get_or_create_criteria
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGetOrCreateCriteria:
+    def test_creates_new_criteria(self, db, user):
+        """First call creates ScreeningCriteria for user."""
+        c = get_or_create_criteria(user)
+        assert c.user == user
+        assert c.min_gross_yield_pct == Decimal("7.00")
+
+    def test_returns_existing_criteria(self, db, user):
+        """Second call returns existing criteria."""
+        c1 = get_or_create_criteria(user)
+        c2 = get_or_create_criteria(user)
+        assert c1.pk == c2.pk
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  HARD KILL CRITERIA
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestHardKillStateFilter:
+    def test_kills_unallowed_state(self, db, configured_criteria, user):
+        """State filter kills property with non-allowed state."""
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="manual",
+            source_id="m-state-kill",
+            address="999 Kill State",
+            address_hash="kill-state",
+            price=Decimal("250000"),
+        )
+        pp.save()
+
+        # PP has no source_record, so state is None → killed by active state filter
+        result = screen_property(pp, configured_criteria)
+        assert not result.passed
+        assert len(result.hard_failures) == 1
+        assert "no state data" in result.hard_failures[0]
+        assert result.score == Decimal("0")
+
+    def test_passes_allowed_state(self, db, configured_criteria, user, vrm_property):
+        """Property in allowed state passes state filter."""
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="vrm",
+            source_id="vrm-999",
+            address="456 Oak Ave, Austin, TX 78701",
+            address_hash="def456",
+            price=Decimal("250000"),
+            estimated_rent=Decimal("2200"),
+            beds=3,
+            year_built=2015,
+        )
+        pp.save()
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.save()
+
+        result = screen_property(pp, configured_criteria, vrm_property)
+        assert result.passed
+        assert len(result.hard_failures) == 0
+
+    def test_kills_missing_state_when_filter_active(
+        self, db, configured_criteria, pipeline_property_base
+    ):
+        """Kills if state filter active but no state data available."""
+        result = screen_property(pipeline_property_base, configured_criteria)
+        assert not result.passed
+        assert "no state data" in result.hard_failures[0]
+
+
+class TestHardKillPropertyType:
+    def test_kills_unallowed_type(self, db, configured_criteria, user):
+        """Property type filter kills non-allowed type."""
+        from django.utils import timezone
+        from core.models import PipelineProperty
+        from core.models import VrmProperty as VP
+
+        now = timezone.now()
+        pp = PipelineProperty(
+            user=user,
+            source_type="vrm",
+            source_id="vrm-998",
+            address="101 Pine, Austin, TX 78701",
+            address_hash="ghi789",
+            price=Decimal("300000"),
+            estimated_rent=Decimal("2000"),
+            beds=3,
+        )
+        pp.save()
+
+        vp = VP(
+            vrm_property_id=998,
+            vrm_listing_url="https://example.com/998",
+            address="101 Pine",
+            city="Austin",
+            state="TX",
+            zip_code="78701",
+            list_price=Decimal("300000"),
+            bedrooms=3,
+            property_type="commercial",
+            status=VP.Status.FOR_SALE,
+            scraped_at=now,
+            last_seen_at=now,
+        )
+        vp.save()
+
+        result = screen_property(pp, configured_criteria, vp)
+        assert not result.passed
+        assert "not in allowed types" in result.hard_failures[0]
+
+    def test_passes_allowed_type(self, db, configured_criteria, vrm_property, user):
+        """Allowed property type passes."""
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="vrm",
+            source_id="vrm-999",
+            address="456 Oak Ave, Austin, TX 78701",
+            address_hash="def456",
+            price=Decimal("250000"),
+            estimated_rent=Decimal("2200"),
+            beds=3,
+            year_built=2015,
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria, vrm_property)
+        assert result.passed
+
+    def test_skips_when_no_property_type_data(
+        self, db, configured_criteria, pipeline_property_base, vrm_property
+    ):
+        """No property type data → SKIPPED note, not a kill."""
+        vrm_property.property_type = ""
+        vrm_property.save()
+
+        result = screen_property(
+            pipeline_property_base, configured_criteria, vrm_property
+        )
+        # Should kill for state not TX, but property type check is skipped
+        assert "no property_type data available" in str(result.passes)
+
+
+class TestHardKillPriceRange:
+    def test_kills_above_max_price(self, db, configured_criteria, user):
+        """Price above max kills."""
+        configured_criteria.allowed_states = []
+        configured_criteria.save()
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="manual",
+            source_id="m-001",
+            address="999 High St",
+            address_hash="aaa",
+            price=Decimal("600000"),
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria)
+        assert not result.passed
+        assert "exceeds max" in result.hard_failures[0]
+
+    def test_kills_below_min_price(self, db, configured_criteria, user):
+        """Price below min kills."""
+        configured_criteria.allowed_states = []
+        configured_criteria.save()
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="manual",
+            source_id="m-002",
+            address="888 Low St",
+            address_hash="bbb",
+            price=Decimal("50000"),
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria)
+        assert not result.passed
+        assert "below min" in result.hard_failures[0]
+
+    def test_passes_within_price_range(self, db, configured_criteria, user):
+        """Price within range passes."""
+        configured_criteria.allowed_states = []
+        configured_criteria.allowed_property_types = []
+        configured_criteria.allowed_foreclosure_statuses = []
+        configured_criteria.save()
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="manual",
+            source_id="m-003",
+            address="777 Mid St",
+            address_hash="ccc",
+            price=Decimal("250000"),
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria)
+        assert result.passed
+
+    def test_skips_when_no_price(self, db, configured_criteria, user):
+        """No price → SKIPPED."""
+        configured_criteria.allowed_states = []
+        configured_criteria.save()
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="manual",
+            source_id="m-004",
+            address="666 No Price St",
+            address_hash="ddd",
+            price=None,
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria)
+        assert "SKIPPED: Price range check" in str(result.passes)
+
+
+class TestHardKillForeclosureStatus:
+    def test_kills_unallowed_status(
+        self, db, configured_criteria, foreclosure_property, user
+    ):
+        """Foreclosure status filter kills non-allowed status."""
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="foreclosure",
+            source_id="fc-prop-001",
+            address="789 Elm St, Dallas, TX 75201",
+            address_hash="eee",
+            price=Decimal("200000"),
+            beds=3,
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria, foreclosure_property)
+        # Should pass (TX allowed, single-family allowed, price OK)
+        assert result.passed
+
+    def test_kills_disallowed_foreclosure_status(
+        self, db, configured_criteria, foreclosure_property, user
+    ):
+        foreclosure_property.foreclosure_status = "preforeclosure"
+        foreclosure_property.save()
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="foreclosure",
+            source_id="fc-prop-001",
+            address="789 Elm St, Dallas, TX 75201",
+            address_hash="fff",
+            price=Decimal("200000"),
+            beds=3,
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria, foreclosure_property)
+        assert not result.passed
+        assert "not in allowed" in result.hard_failures[0]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  SOFT CRITERIA
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSoftGacsScore:
+    def test_deducts_when_below_minimum(
+        self, db, configured_criteria, pipeline_property_base, vrm_property, growth_area
+    ):
+        """GACS score below minimum deducts points."""
+        configured_criteria.min_gacs_score = Decimal("70")
+        configured_criteria.save()
+        # Update growth_area with a score we control
+        growth_area.composite_score = Decimal("50.00")
+        growth_area.save()
+
+        # Need state=TX in allowed for pipeline with TX source
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.save()
+
+        result = screen_property(
+            pipeline_property_base, configured_criteria, vrm_property
+        )
+        assert result.score < Decimal("100")
+        assert any("below minimum" in f for f in result.soft_failures)
+
+    def test_skips_when_no_minimum(self, db, criteria, pipeline_property_base):
+        """No min GACS → skip."""
+        criteria.min_gacs_score = None
+        criteria.save()
+
+        result = screen_property(pipeline_property_base, criteria)
+        assert "GACS score screening skipped" in str(result.passes)
+
+    def test_skips_when_no_growth_area(
+        self, db, configured_criteria, pipeline_property_base, vrm_property
+    ):
+        """No GrowthArea found → skip with note."""
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.save()
+
+        result = screen_property(
+            pipeline_property_base, configured_criteria, vrm_property
+        )
+        assert "no GrowthArea found" in str(result.passes)
+
+
+class TestSoftGrossYield:
+    def test_deducts_when_below_minimum(
+        self, db, configured_criteria, user, vrm_property, growth_area
+    ):
+        """Gross yield below minimum deducts points."""
+        # vrm_property: price=250000, rent=2200 → yield = (2200*12/250000)*100 = 10.56%
+        # Set minimum higher
+        configured_criteria.min_gross_yield_pct = Decimal("12.00")
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.save()
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="vrm",
+            source_id="vrm-999",
+            address="456 Oak Ave",
+            address_hash="vrm-hash",
+            price=Decimal("250000"),
+            estimated_rent=Decimal("2200"),
+            beds=3,
+            year_built=2015,
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria, vrm_property)
+        assert result.score < Decimal("100")
+        assert any("below minimum" in f for f in result.soft_failures)
+
+    def test_skip_with_foreclosure_source(
+        self, db, configured_criteria, user, foreclosure_property, growth_area
+    ):
+        """ForeclosureProperty → yield skipped."""
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.save()
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="foreclosure",
+            source_id="fc-prop-001",
+            address="789 Elm St",
+            address_hash="fc-hash",
+            price=Decimal("200000"),
+            beds=3,
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria, foreclosure_property)
+        # Check that yield/PTR were noted as skipped
+        assert "no rent estimate available" in result.notes
+
+
+class TestSoftPriceToRentRatio:
+    def test_deducts_when_above_maximum(
+        self, db, configured_criteria, user, vrm_property, growth_area
+    ):
+        """PTR above maximum deducts points."""
+        configured_criteria.max_price_to_rent_ratio = Decimal("8.00")
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.save()
+        # vrm: price=250000, rent=2200 → PTR = 250000/2200 = 113.6
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="vrm",
+            source_id="vrm-999",
+            address="456 Oak Ave",
+            address_hash="vrm-hash",
+            price=Decimal("250000"),
+            estimated_rent=Decimal("2200"),
+            beds=3,
+            year_built=2015,
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria, vrm_property)
+        assert result.score < Decimal("100")
+        assert any("above maximum" in f for f in result.soft_failures)
+
+    def test_skip_when_no_rent(self, db, configured_criteria, user):
+        """No rent → PTR skipped."""
+        configured_criteria.allowed_states = []
+        configured_criteria.save()
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="manual",
+            source_id="m-rentless",
+            address="555 No Rent",
+            address_hash="norent",
+            price=Decimal("250000"),
+            estimated_rent=None,
+            beds=3,
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria)
+        assert "no rent estimate available" in str(result.passes)
+
+
+class TestSoftYearBuilt:
+    def test_deducts_when_too_old(
+        self, db, configured_criteria, pipeline_property_base, vrm_property
+    ):
+        """Year built before cutoff → deducts 5 points."""
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.save()
+
+        result = screen_property(
+            pipeline_property_base, configured_criteria, vrm_property
+        )
+        # pipeline_property_base has year_built=2010, cutoff is 2000 → passes
+        assert not any("older than cutoff" in f for f in result.soft_failures)
+
+    def test_deducts_when_older_than_max(
+        self, db, configured_criteria, user, vrm_property
+    ):
+        """Year built older than max_year_built → deducts 5 points."""
+        configured_criteria.max_year_built = 2020
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.save()
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="vrm",
+            source_id="vrm-997",
+            address="111 Old House",
+            address_hash="old-hash",
+            price=Decimal("200000"),
+            estimated_rent=Decimal("1800"),
+            beds=3,
+            year_built=1995,
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria, vrm_property)
+        assert any("older than cutoff" in f for f in result.soft_failures)
+        assert result.score <= Decimal("95")  # 100 - 5
+
+    def test_skip_when_no_year_built(self, db, configured_criteria, user):
+        """No year_built → skip."""
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="manual",
+            source_id="m-010",
+            address="222 Unknown",
+            address_hash="unk-hash",
+            price=Decimal("200000"),
+            beds=3,
+        )
+        pp.save()
+        configured_criteria.allowed_states = []
+        configured_criteria.save()
+
+        result = screen_property(pp, configured_criteria)
+        assert "no year_built data" in str(result.passes)
+
+
+class TestSoftBeds:
+    def test_deducts_when_below_min(
+        self, db, configured_criteria, pipeline_property_base, vrm_property
+    ):
+        """Beds below minimum → deducts."""
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.min_beds = 4
+        configured_criteria.save()
+        # pipeline_property_base has beds=3
+
+        result = screen_property(
+            pipeline_property_base, configured_criteria, vrm_property
+        )
+        assert any("below minimum" in f for f in result.soft_failures)
+        assert result.score <= Decimal("95")  # 100 - 5
+
+    def test_deducts_when_above_max(self, db, configured_criteria, user, vrm_property):
+        """Beds above maximum → deducts."""
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.max_beds = 2
+        configured_criteria.save()
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="vrm",
+            source_id="vrm-996",
+            address="333 Big House",
+            address_hash="big-hash",
+            price=Decimal("300000"),
+            estimated_rent=Decimal("2500"),
+            beds=5,
+            year_built=2020,
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria, vrm_property)
+        assert any("above maximum" in f for f in result.soft_failures)
+
+    def test_skips_when_no_beds(self, db, configured_criteria, user):
+        """No beds → skip."""
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="manual",
+            source_id="m-011",
+            address="444 No Beds",
+            address_hash="no-bed",
+            price=Decimal("200000"),
+        )
+        pp.save()
+        configured_criteria.allowed_states = []
+        configured_criteria.save()
+
+        result = screen_property(pp, configured_criteria)
+        assert "no beds data" in str(result.passes)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+#  INTEGRATION / EDGE CASES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestIntegration:
+    def test_all_pass_with_vrm_source(
+        self, db, configured_criteria, user, vrm_property, growth_area
+    ):
+        """All criteria met, VrmProperty source, everything passes."""
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.max_price_to_rent_ratio = Decimal("200")
+        configured_criteria.min_gacs_score = Decimal("10")
+        configured_criteria.save()
+        # growth_area composite_score will be computed on save as ~19.68
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="vrm",
+            source_id="vrm-999",
+            address="456 Oak Ave",
+            address_hash="all-pass",
+            price=Decimal("250000"),
+            estimated_rent=Decimal("2200"),
+            beds=3,
+            year_built=2015,
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria, vrm_property)
+        assert result.passed
+        assert result.score == Decimal("100")
+        assert len(result.hard_failures) == 0
+        assert len(result.soft_failures) == 0
+        assert len(result.passes) >= 5
+
+    def test_foreclosure_property_skips_yield(
+        self, db, configured_criteria, user, foreclosure_property, growth_area
+    ):
+        """ForeclosureProperty source → yield/PTR noted as skipped."""
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.save()
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="foreclosure",
+            source_id="fc-prop-001",
+            address="789 Elm St",
+            address_hash="fc-pass",
+            price=Decimal("200000"),
+            beds=3,
+            year_built=2005,
+        )
+        pp.save()
+
+        result = screen_property(pp, configured_criteria, foreclosure_property)
+        assert result.passed
+        assert "no rent estimate available" in result.notes
+
+    def test_no_criteria_set_defaults(self, db, criteria, user):
+        """All criteria at defaults (none/empty) — passes without deductions."""
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="manual",
+            source_id="m-100",
+            address="123 Defaults St",
+            address_hash="defaults",
+            price=Decimal("250000"),
+            # No estimated_rent → yield/PTR skipped
+            beds=3,
+            year_built=2010,
+        )
+        pp.save()
+
+        result = screen_property(pp, criteria)
+        assert result.passed
+        assert result.score == Decimal("100")
+        # All soft criteria should have been skipped with notes
+        skip_count = sum(1 for p in result.passes if "skipped" in p.lower())
+        assert skip_count >= 3
+
+    def test_missing_data_graceful(self, db, user):
+        """PipelineProperty with minimal data — gracefully skips all checks."""
+        from core.models import PipelineProperty, ScreeningCriteria
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="manual",
+            source_id="m-999",
+            address="555 Minimal",
+            address_hash="minimal",
+            price=None,
+            beds=None,
+        )
+        pp.save()
+
+        criteria = ScreeningCriteria.objects.create(user=user)
+
+        result = screen_property(pp, criteria)
+        assert result.passed
+        assert result.score == Decimal("100")
+
+    def test_vrm_source_uses_project_rent(
+        self, db, configured_criteria, user, vrm_property, growth_area
+    ):
+        """VrmProperty's projected_monthly_rent is preferred over PP estimated_rent."""
+        configured_criteria.max_price_to_rent_ratio = Decimal("100.00")
+        configured_criteria.allowed_states = ["TX"]
+        configured_criteria.save()
+        growth_area.composite_score = Decimal("50.00")
+        growth_area.save()
+
+        from core.models import PipelineProperty
+
+        pp = PipelineProperty(
+            user=user,
+            source_type="vrm",
+            source_id="vrm-999",
+            address="456 Oak Ave",
+            address_hash="vrm-rent",
+            price=Decimal("250000"),
+            estimated_rent=Decimal("500"),  # Low — should NOT be used
+            beds=3,
+            year_built=2015,
+        )
+        pp.save()
+
+        # vrm_property has projected_monthly_rent=2200
+        result = screen_property(pp, configured_criteria, vrm_property)
+        # PTR = 250000/2200 ≈ 113.6 → above 100 → should deduct
+        # If PP.estimated_rent (500) was used, PTR = 250000/500 = 500 → even worse
+        assert any("above maximum" in f for f in result.soft_failures)


### PR DESCRIPTION
## Problem

PipelineProperty instances lack a dedicated service for lifecycle operations. Stage advancement, kill/hold/reactivate flows, source record resolution, and conversion to Property records are all handled ad-hoc.

## Solution

Created `core/services/pipeline.py` as the authoritative pipeline lifecycle service:

### Core Operations
- **advance_stage()** — moves to next stage, sets corresponding timestamp, saves with update_fields. Raises ValueError for KILLED/ON_HOLD/STABILIZED.
- **kill_property()** — sets status=KILLED, records kill_reason
- **hold_property()** — sets status=ON_HOLD, optional reason
- **reactivate_property()** — returns KILLED/ON_HOLD → ACTIVE at current stage

### Source Resolution
- **get_source_record()** — resolves vrm→VrmProperty, foreclosure→ForeclosureProperty, listing→Listing. Returns None for manual/unrecognised types.

### Creation from Sources
- **create_from_vrm()** — creates PipelineProperty denormalizing VrmProperty fields, runs screen_property() immediately, sets stage=SCREENING
- **create_from_foreclosure()** — same pattern, yield/PTR auto-skipped for lack of rent data

### Acquisition
- **convert_to_property_record()** — creates Property record in transaction.atomic(), sets back-link, marks pipeline as ACQUIRED. Raises ValueError on duplicate conversion.

## Validation

- `python -m pytest tests/test_pipeline_service.py`: **35 passed**
- `python -m pytest tests/test_pipeline_service.py tests/test_screening.py tests/test_pipeline.py prei/pipeline/tests/`: **323 passed**
- `python manage.py test core.tests`: **23 passed**
- Pre-commit: ruff, mypy, bandit, secrets all pass

## Risks

- Low. No new migrations, no schema changes. Depends on PIPE-1 models and PIPE-2 screening service.
- convert_to_property_record runs in transaction.atomic() — partially-applied conversions are rolled back on failure.

## Test Coverage (35 tests)

| Area | Tests |
|---|---|
| STAGE_ORDER | 3 |
| advance_stage | 6 |
| kill_property | 2 |
| hold_property | 3 |
| reactivate_property | 3 |
| get_source_record | 5 |
| create_from_vrm | 4 |
| create_from_foreclosure | 4 |
| convert_to_property_record | 5 |

Closes: PIPE-3 (Build pipeline service)