### PR TITLE
feat(views): pipe-4 - build pipeline list and detail views

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -58,6 +58,8 @@ urlpatterns = [
     path("vrm-properties/", views.vrm_properties_list, name="vrm_properties_list"),
     path("growth-explorer/", views.growth_explorer, name="growth_explorer"),
     path("pipeline/", views.pipeline_dashboard, name="pipeline_dashboard"),
+    path("pipeline/list/", views.pipeline_list, name="pipeline_list"),
+    path("pipeline/<int:pk>/", views.pipeline_detail, name="pipeline_detail"),
     path(
         "settings/investment-targets/",
         views.investment_targets_edit,

--- a/core/views.py
+++ b/core/views.py
@@ -1085,6 +1085,128 @@ def pipeline_dashboard(request: HttpRequest) -> HttpResponse:
     )
 
 
+def pipeline_list(request: HttpRequest) -> HttpResponse:
+    """Pipeline property list with stage funnel and filtering.
+
+    GET params:
+      status: filter by status (ACTIVE, KILLED, ON_HOLD) — default ACTIVE
+      stage:  filter by stage (SCREENING, UNDERWRITING, etc) — optional
+    """
+    from core.models import PipelineProperty
+
+    status_filter = request.GET.get("status", "ACTIVE")
+    stage_filter = request.GET.get("stage", "")
+
+    qs = (
+        PipelineProperty.objects.filter(user=request.user)
+        .select_related("investment_analysis", "property_record")
+        .order_by("-updated_at")
+    )
+
+    if status_filter:
+        qs = qs.filter(status=status_filter)
+    if stage_filter:
+        qs = qs.filter(stage=stage_filter)
+
+    # Stage counts for funnel header
+    all_user_props = PipelineProperty.objects.filter(user=request.user)
+    stage_counts: dict[str, int] = {}
+    for pp in all_user_props:
+        stage_counts[pp.stage] = stage_counts.get(pp.stage, 0) + 1
+
+    # Build ordered list of (stage_label, count) for template display
+    stage_order = [
+        "DISCOVERED",
+        "SCREENING",
+        "UNDERWRITING",
+        "OFFER",
+        "DUE_DILIGENCE",
+        "CLOSING",
+        "ACQUIRED",
+        "RENOVATION",
+        "STABILIZED",
+    ]
+    stage_items = [(s, stage_counts.get(s, 0)) for s in stage_order]
+
+    return render(
+        request,
+        "pipeline/pipeline_list.html",
+        {
+            "properties": qs,
+            "stage_items": stage_items,
+            "current_status": status_filter,
+            "current_stage": stage_filter,
+            "status_choices": [
+                ("ACTIVE", "Active"),
+                ("KILLED", "Killed"),
+                ("ON_HOLD", "On Hold"),
+            ],
+        },
+    )
+
+
+def pipeline_detail(request: HttpRequest, pk: int) -> HttpResponse:
+    """Pipeline property detail view.
+
+    Shows all pipeline fields, source record data, stage history,
+    and action buttons. 404 if not the user's property.
+    """
+    from core.models import PipelineProperty
+    from core.services.pipeline import get_source_record
+
+    try:
+        prop = PipelineProperty.objects.get(pk=pk, user=request.user)
+    except PipelineProperty.DoesNotExist:
+        raise Http404
+
+    source_record = get_source_record(prop)
+
+    # Stage history: build list of (stage_name, timestamp) skipping None
+    stage_fields = [
+        ("DISCOVERED", prop.discovered_at),
+        ("SCREENING", prop.screening_at),
+        ("UNDERWRITING", prop.underwriting_at),
+        ("OFFER", prop.offer_at),
+        ("DUE_DILIGENCE", prop.due_diligence_at),
+        ("CLOSING", prop.closing_at),
+        ("ACQUIRED", prop.acquired_at),
+        ("RENOVATION", prop.renovation_at),
+        ("STABILIZED", prop.stabilized_at),
+    ]
+    stage_history = [(s, t) for s, t in stage_fields if t is not None]
+
+    # Days in pipeline
+    if prop.discovered_at:
+        days_in_pipeline = (timezone.now() - prop.discovered_at).days
+    else:
+        days_in_pipeline = 0
+
+    # Kill reason suggestions (shared with template)
+    kill_reasons = [
+        "Price too high",
+        "Low yield",
+        "Poor condition",
+        "Bad market",
+        "Financing fell through",
+        "Lost to other buyer",
+        "Failed inspection",
+        "Title issues",
+        "Other",
+    ]
+
+    return render(
+        request,
+        "pipeline/pipeline_detail.html",
+        {
+            "prop": prop,
+            "source_record": source_record,
+            "stage_history": stage_history,
+            "days_in_pipeline": days_in_pipeline,
+            "kill_reasons": kill_reasons,
+        },
+    )
+
+
 def search_listings(request):
     # Optionally load a saved search to prefill filters
     saved_id = request.GET.get("saved_id")

--- a/static/css/pipeline.css
+++ b/static/css/pipeline.css
@@ -1,0 +1,423 @@
+/* ── Pipeline list / detail styles ──────────────────────────────────── */
+/* Uses design tokens from tokens.css — no hardcoded hex colors.       */
+
+/* ── List view ──────────────────────────────────────────────────────── */
+.pipeline-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--sp-6) var(--sp-4);
+}
+
+.pipeline-page h1 {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-medium);
+  margin: 0 0 var(--sp-6);
+}
+
+/* Funnel header */
+.pipeline-funnel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-1);
+  margin-bottom: var(--sp-6);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--surface-secondary);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.pipeline-funnel a {
+  color: var(--color-neutral-900);
+  text-decoration: none;
+}
+
+.pipeline-funnel-stage {
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
+}
+
+.pipeline-funnel-stage.active {
+  background: var(--color-primary-bg);
+}
+
+/* Status filter tabs */
+.pipeline-status-tabs {
+  display: flex;
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-6);
+  font-size: var(--text-sm);
+}
+
+.pipeline-status-tab {
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius-pill);
+  text-decoration: none;
+  font-weight: var(--weight-medium);
+  background: var(--surface-secondary);
+  color: var(--color-neutral-900);
+}
+
+.pipeline-status-tab.active-active {
+  background: var(--color-primary);
+  color: white;
+}
+
+.pipeline-status-tab.active-killed {
+  background: var(--color-risk-400);
+  color: white;
+}
+
+.pipeline-status-tab.active-on_hold {
+  background: var(--color-caution-400);
+  color: white;
+}
+
+/* Property cards grid */
+.pipeline-cards {
+  display: grid;
+  gap: var(--sp-4);
+  grid-template-columns: 1fr;
+}
+
+.pipeline-card {
+  background: var(--surface-card);
+  border: var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--sp-4);
+}
+
+.pipeline-card-body {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+}
+
+.pipeline-card-info {
+  flex: 1;
+  min-width: 200px;
+}
+
+.pipeline-card-badges {
+  display: flex;
+  gap: var(--sp-2);
+  align-items: center;
+  margin-bottom: var(--sp-2);
+  flex-wrap: wrap;
+}
+
+.pipeline-badge {
+  font-size: var(--text-xs);
+  padding: 2px var(--sp-2);
+  border-radius: var(--radius-sm);
+  font-weight: var(--weight-medium);
+}
+
+.badge-source {
+  background: var(--color-primary-bg);
+  color: var(--color-primary-text);
+  text-transform: uppercase;
+}
+
+.badge-stage {
+  background: var(--surface-secondary);
+  color: var(--color-neutral-700);
+}
+
+.badge-status-active {
+  background: var(--color-verdict-a-bg);
+  color: var(--color-verdict-a-text);
+}
+
+.badge-status-killed {
+  background: var(--color-verdict-c-bg);
+  color: var(--color-verdict-c-text);
+}
+
+.badge-status-on_hold {
+  background: var(--color-verdict-b-bg);
+  color: var(--color-verdict-b-text);
+}
+
+.pipeline-card-address {
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  color: var(--color-neutral-900);
+  margin-bottom: var(--sp-1);
+}
+
+.pipeline-card-meta {
+  font-size: var(--text-sm);
+  color: var(--color-neutral-500);
+}
+
+.pipeline-card-actions {
+  text-align: right;
+  min-width: 180px;
+}
+
+.pipeline-screening-result {
+  font-size: var(--text-sm);
+  margin-bottom: var(--sp-2);
+}
+
+.pipeline-screening-result.passed {
+  color: var(--color-verdict-a-text);
+}
+
+.pipeline-screening-result.failed {
+  color: var(--color-verdict-c-text);
+}
+
+.pipeline-days {
+  font-size: var(--text-xs);
+  color: var(--color-neutral-500);
+  margin-bottom: var(--sp-3);
+}
+
+.pipeline-card-btn-group {
+  display: flex;
+  gap: var(--sp-1);
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.pipeline-action-btn {
+  padding: var(--sp-1) var(--sp-2);
+  font-size: var(--text-xs);
+  border: var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--surface-card);
+  color: var(--color-neutral-900);
+  text-decoration: none;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.pipeline-action-btn.primary {
+  background: var(--color-primary);
+  color: white;
+  border: none;
+}
+
+.pipeline-action-btn.placeholder {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.pipeline-empty {
+  padding: var(--sp-8);
+  text-align: center;
+  color: var(--color-neutral-500);
+  font-size: var(--text-sm);
+  background: var(--surface-secondary);
+  border-radius: var(--radius-md);
+}
+
+/* ── Detail view ────────────────────────────────────────────────────── */
+.pipeline-detail-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--sp-4);
+}
+
+.pipeline-detail-section {
+  background: var(--surface-card);
+  border: var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--sp-4);
+}
+
+.pipeline-detail-section.full-width {
+  grid-column: 1 / -1;
+}
+
+.pipeline-detail-section h2 {
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  margin: 0 0 var(--sp-3);
+}
+
+.pipeline-detail-table {
+  width: 100%;
+  font-size: var(--text-sm);
+  border-collapse: collapse;
+}
+
+.pipeline-detail-table td {
+  padding: var(--sp-1) 0;
+}
+
+.pipeline-detail-table td:first-child {
+  color: var(--color-neutral-500);
+  width: 40%;
+}
+
+/* Stage history */
+.stage-history {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.stage-history-item {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-2);
+  background: var(--surface-page);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+}
+
+.stage-history-name {
+  font-weight: var(--weight-medium);
+  min-width: 140px;
+}
+
+.stage-history-time {
+  color: var(--color-neutral-500);
+}
+
+.stage-history-current {
+  font-size: var(--text-xs);
+  padding: 1px var(--sp-2);
+  border-radius: var(--radius-sm);
+  background: var(--color-primary-bg);
+  color: var(--color-primary-text);
+}
+
+/* Detail header */
+.pipeline-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-6);
+}
+
+.pipeline-detail-header .back-link {
+  font-size: var(--text-sm);
+  color: var(--color-neutral-500);
+  text-decoration: none;
+}
+
+.pipeline-detail-header h1 {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-medium);
+  margin: var(--sp-2) 0 0;
+}
+
+/* Detail inline verdict badges */
+.verdict-pass {
+  color: var(--color-verdict-a-text);
+}
+
+.verdict-fail {
+  color: var(--color-verdict-c-text);
+}
+
+.text-muted {
+  font-size: var(--text-sm);
+  color: var(--color-neutral-500);
+}
+
+.text-danger {
+  color: var(--color-risk-700);
+}
+
+/* Action button bar */
+.pipeline-action-bar {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+  padding: var(--sp-4) 0;
+}
+
+.pipeline-action-bar .btn {
+  padding: var(--sp-2) var(--sp-4);
+  font-size: var(--text-sm);
+  border-radius: var(--radius-sm);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  border: none;
+}
+
+.pipeline-action-bar .btn-primary {
+  background: var(--color-primary);
+  color: white;
+}
+
+.pipeline-action-bar .btn-danger {
+  background: white;
+  color: var(--color-risk-400);
+  border: 1px solid var(--color-risk-400);
+}
+
+.pipeline-action-bar .btn-outline {
+  background: white;
+  color: var(--color-neutral-700);
+  border: var(--border-default);
+}
+
+.pipeline-action-bar .btn-warning {
+  background: var(--color-caution-400);
+  color: white;
+}
+
+.pipeline-action-bar .btn-placeholder {
+  opacity: 0.7;
+  cursor: default;
+}
+
+/* Kill modal */
+.pipeline-modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.4);
+  z-index: 100;
+}
+
+.pipeline-modal-content {
+  background: white;
+  max-width: 400px;
+  margin: 15% auto;
+  padding: var(--sp-6);
+  border-radius: var(--radius-lg);
+}
+
+.pipeline-modal h3 {
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  margin: 0 0 var(--sp-3);
+}
+
+.pipeline-modal label {
+  font-size: var(--text-sm);
+  color: var(--color-neutral-500);
+  display: block;
+  margin-bottom: var(--sp-2);
+}
+
+.pipeline-modal input {
+  width: 100%;
+  padding: var(--sp-2);
+  font-size: var(--text-sm);
+  border: var(--border-default);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--sp-3);
+  box-sizing: border-box;
+}
+
+.pipeline-modal-actions {
+  display: flex;
+  gap: var(--sp-2);
+  justify-content: flex-end;
+}

--- a/templates/pipeline/pipeline_detail.html
+++ b/templates/pipeline/pipeline_detail.html
@@ -1,0 +1,151 @@
+{% extends "base.html" %}
+{% load humanize %}
+{% load static %}
+
+{% block title %}Pipeline #{{ prop.pk }} — prei{% endblock %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'css/pipeline.css' %}">
+{% endblock %}
+
+{% block content %}
+<div class="pipeline-page">
+
+  {# Header #}
+  <div class="pipeline-detail-header">
+    <div>
+      <a href="{% url 'pipeline_list' %}" class="back-link">&larr; Back to Pipeline</a>
+      <h1>{{ prop.address|truncatechars:60 }}</h1>
+    </div>
+    <div class="pipeline-card-badges">
+      <span class="pipeline-badge badge-source">{{ prop.source_type }}</span>
+      <span class="pipeline-badge badge-stage">{{ prop.stage|title }}</span>
+      <span class="pipeline-badge badge-status-{{ prop.status|lower }}">{{ prop.status|title }}</span>
+    </div>
+  </div>
+
+  {# Main content grid #}
+  <div class="pipeline-detail-body">
+
+    {# Left: property details #}
+    <div class="pipeline-detail-section">
+      <h2>Property Details</h2>
+      <table class="pipeline-detail-table">
+        <tr><td>Address</td><td>{{ prop.address }}</td></tr>
+        {% if source_record.city %}<tr><td>City</td><td>{{ source_record.city }}</td></tr>{% endif %}
+        {% if source_record.state %}<tr><td>State</td><td>{{ source_record.state }}</td></tr>{% endif %}
+        {% if prop.price %}<tr><td>Price</td><td>${{ prop.price|floatformat:2|intcomma }}</td></tr>{% endif %}
+        {% if prop.estimated_rent %}<tr><td>Est. Monthly Rent</td><td>${{ prop.estimated_rent|floatformat:2|intcomma }}</td></tr>{% endif %}
+        {% if prop.beds %}<tr><td>Beds</td><td>{{ prop.beds }}</td></tr>{% endif %}
+        {% if prop.baths %}<tr><td>Baths</td><td>{{ prop.baths }}</td></tr>{% endif %}
+        {% if prop.sqft %}<tr><td>Sq Ft</td><td>{{ prop.sqft|floatformat:0 }}</td></tr>{% endif %}
+        {% if prop.year_built %}<tr><td>Year Built</td><td>{{ prop.year_built }}</td></tr>{% endif %}
+      </table>
+    </div>
+
+    {# Right: pipeline info #}
+    <div class="pipeline-detail-section">
+      <h2>Pipeline Info</h2>
+      <table class="pipeline-detail-table">
+        <tr><td>Source</td><td>{{ prop.source_type|title }} #{{ prop.source_id }}</td></tr>
+        <tr><td>Stage</td><td>{{ prop.stage|title }}</td></tr>
+        <tr><td>Status</td><td>{{ prop.status|title }}</td></tr>
+        {% if prop.screening_passed is not None %}
+        <tr><td>Screening</td><td>{% if prop.screening_passed %}<span class="verdict-pass">PASSED</span>{% else %}<span class="verdict-fail">FAILED</span>{% endif %}</td></tr>
+        {% endif %}
+        <tr><td>Days in Pipeline</td><td>{{ days_in_pipeline }} days</td></tr>
+        {% if prop.investment_analysis %}<tr><td>Analysis</td><td>#{{ prop.investment_analysis.pk }}</td></tr>{% endif %}
+        {% if prop.mao %}<tr><td>MAO</td><td>${{ prop.mao|floatformat:2|intcomma }}</td></tr>{% endif %}
+        {% if prop.property_record %}<tr><td>Property Record</td><td>#{{ prop.property_record.pk }}</td></tr>{% endif %}
+        {% if prop.kill_reason %}<tr><td class="text-danger">Kill Reason</td><td>{{ prop.kill_reason }}</td></tr>{% endif %}
+      </table>
+    </div>
+
+    {# Stage history (full width) #}
+    <div class="pipeline-detail-section full-width">
+      <h2>Stage History</h2>
+      {% if stage_history %}
+        <div class="stage-history">
+        {% for stage_name, ts in stage_history %}
+          <div class="stage-history-item">
+            <span class="stage-history-name">{{ stage_name|title }}</span>
+            <span class="stage-history-time">{{ ts|date:"M j, Y g:i A" }}</span>
+            {% if stage_name == prop.stage %}
+              <span class="stage-history-current">Current</span>
+            {% endif %}
+          </div>
+        {% endfor %}
+        </div>
+      {% else %}
+        <div class="text-muted">No stage history recorded yet.</div>
+      {% endif %}
+    </div>
+
+    {# Source record data (full width) #}
+    {% if source_record %}
+    <div class="pipeline-detail-section full-width">
+      <h2>Source Record</h2>
+      <table class="pipeline-detail-table">
+        {% if source_record.vrm_property_id %}
+        <tr><td>VRM ID</td><td>{{ source_record.vrm_property_id }}</td></tr>
+        {% endif %}
+        {% if source_record.property_id %}
+        <tr><td>Property ID</td><td>{{ source_record.property_id }}</td></tr>
+        {% endif %}
+        {% if source_record.list_price %}
+        <tr><td>List Price</td><td>${{ source_record.list_price|floatformat:2|intcomma }}</td></tr>
+        {% endif %}
+        {% if source_record.opening_bid %}
+        <tr><td>Opening Bid</td><td>${{ source_record.opening_bid|floatformat:2|intcomma }}</td></tr>
+        {% endif %}
+        {% if source_record.foreclosure_status %}
+        <tr><td>Foreclosure Status</td><td>{{ source_record.foreclosure_status|title }}</td></tr>
+        {% endif %}
+        {% if source_record.property_type %}
+        <tr><td>Property Type</td><td>{{ source_record.property_type|title }}</td></tr>
+        {% endif %}
+        {% if source_record.status %}
+        <tr><td>Status</td><td>{{ source_record.status }}</td></tr>
+        {% endif %}
+      </table>
+    </div>
+    {% endif %}
+
+    {# Action buttons #}
+    <div class="pipeline-action-bar">
+      {% if prop.status == 'ACTIVE' and prop.stage != 'STABILIZED' %}
+        <span class="btn btn-primary btn-placeholder">Advance Stage</span>
+      {% endif %}
+      {% if prop.status == 'ACTIVE' %}
+      <span class="btn btn-danger" onclick="document.getElementById('kill-modal').style.display='block'">Kill</span>
+      <span class="btn btn-outline btn-placeholder">Hold</span>
+      {% endif %}
+      {% if prop.status == 'KILLED' or prop.status == 'ON_HOLD' %}
+      <span class="btn btn-warning btn-placeholder">Reactivate</span>
+      {% endif %}
+    </div>
+
+  </div>{# end grid #}
+
+</div>{# end container #}
+
+{# Kill reason modal (UI only) #}
+<div id="kill-modal" class="pipeline-modal">
+  <div class="pipeline-modal-content">
+    <h3>Kill Property</h3>
+    <form>
+      <label for="kill-reason-input">Reason</label>
+      <input id="kill-reason-input" list="kill-reasons" name="reason" required>
+      <datalist id="kill-reasons">
+        {% for reason in kill_reasons %}
+          <option value="{{ reason }}"></option>
+        {% endfor %}
+      </datalist>
+      <div class="pipeline-modal-actions">
+        <button type="button" class="btn btn-outline" onclick="document.getElementById('kill-modal').style.display='none'">Cancel</button>
+        <button type="button" class="btn btn-danger" onclick="document.getElementById('kill-modal').style.display='none'">Kill (not wired)</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/pipeline/pipeline_list.html
+++ b/templates/pipeline/pipeline_list.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+{% load humanize %}
+{% load static %}
+
+{% block title %}Pipeline — prei{% endblock %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'css/pipeline.css' %}">
+{% endblock %}
+
+{% block content %}
+<div class="pipeline-page">
+
+  <h1>Purchase Pipeline</h1>
+
+  {# Funnel header: stage counts #}
+  <div class="pipeline-funnel">
+    {% for stage_label, count in stage_items %}
+      <span class="pipeline-funnel-stage {% if current_stage == stage_label %}active{% endif %}">
+        <a href="?stage={{ stage_label }}&status={{ current_status }}">
+          {{ stage_label|title }} <strong>({{ count }})</strong>
+        </a>
+      </span>
+    {% endfor %}
+  </div>
+
+  {# Status filter tabs #}
+  <div class="pipeline-status-tabs">
+    {% for status_val, status_label in status_choices %}
+      <a href="?status={{ status_val }}{% if current_stage %}&stage={{ current_stage }}{% endif %}"
+         class="pipeline-status-tab active-{{ status_val|lower }}">
+        {{ status_label }}
+      </a>
+    {% endfor %}
+  </div>
+
+  {# Property cards #}
+  {% if properties %}
+    <div class="pipeline-cards">
+    {% for pp in properties %}
+      <div class="pipeline-card">
+        <div class="pipeline-card-body">
+
+          {# Left: identity #}
+          <div class="pipeline-card-info">
+            <div class="pipeline-card-badges">
+              <span class="pipeline-badge badge-source">{{ pp.source_type }}</span>
+              <span class="pipeline-badge badge-stage">{{ pp.stage|title }}</span>
+              <span class="pipeline-badge badge-status-{{ pp.status|lower }}">{{ pp.status|title }}</span>
+            </div>
+            <div class="pipeline-card-address">{{ pp.address|truncatechars:60 }}</div>
+            <div class="pipeline-card-meta">
+              {% if pp.price %}Price: ${{ pp.price|floatformat:0|intcomma }}{% endif %}
+              {% if pp.beds and pp.baths %} &middot; {{ pp.beds }} bed / {{ pp.baths }} bath{% endif %}
+              {% if pp.sqft %} &middot; {{ pp.sqft|floatformat:0 }} sqft{% endif %}
+            </div>
+          </div>
+
+          {# Right: screening result + actions #}
+          <div class="pipeline-card-actions">
+            {% if pp.screening_passed is not None %}
+              <div class="pipeline-screening-result {% if pp.screening_passed %}passed{% else %}failed{% endif %}">
+                {% if pp.screening_passed %}PASSED{% else %}FAILED{% endif %}
+              </div>
+            {% endif %}
+            {% if pp.discovered_at %}
+              <div class="pipeline-days">{{ pp.discovered_at|timesince }} in pipeline</div>
+            {% endif %}
+            <div class="pipeline-card-btn-group">
+              {% if pp.status == 'ACTIVE' and pp.stage != 'STABILIZED' %}
+                <a href="{% url 'pipeline_detail' pp.pk %}" class="pipeline-action-btn primary placeholder">Advance</a>
+              {% endif %}
+              <a href="{% url 'pipeline_detail' pp.pk %}" class="pipeline-action-btn">View Details</a>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    {% endfor %}
+    </div>
+  {% else %}
+    <div class="pipeline-empty">No pipeline properties found.</div>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Problem

Pipeline dashboard exists but uses the old PipelineAsset model. No dedicated list/detail views exist for the new PipelineProperty model.

## Solution

Added pipeline_list and pipeline_detail views with templates:

### pipeline_list (/pipeline/list/)
- Stage funnel header: count per stage with clickable filter links
- Status filter tabs: Active / Killed / On Hold
- Property cards: source badge, stage badge, status badge, address, price, beds/baths/sqft, screening PASSED/FAILED, days in pipeline, action buttons
- CSS classes from pipeline.css using tokens.css custom properties

### pipeline_detail (/pipeline/<pk>/)
- Property details table
- Pipeline info table (source, stage, status, screening, days, MAO, kill reason)
- Stage history: chronological list with timestamps (skipping None)
- Source record data (VRM / Foreclosure fields)
- Action buttons: Advance Stage, Kill (with modal + datalist of 9 common reasons), Hold, Reactivate
- 404 enforcement for non-owner access

### Design Compliance
- CSS custom properties from tokens.css throughout
- No Bootstrap classes, no `!important`
- pipeline.css provides all layout/component classes
- djlint H021 inline-style check passes

## Files Changed
| File | Change |
|---|---|
| core/views.py | Added pipeline_list + pipeline_detail views (preserved existing pipeline_dashboard) |
| core/urls.py | Added /pipeline/list/ and /pipeline/<pk>/ routes |
| templates/pipeline/pipeline_list.html | New — list view with funnel + cards |
| templates/pipeline/pipeline_detail.html | New — detail with tables + stage history + kill modal |
| static/css/pipeline.css | New — all pipeline component styles using tokens |

## Validation
- `python manage.py check`: No issues
- `python -m pytest`: 323 passed
- Pre-commit: ruff, mypy, djlint, commitizen, bandit, secrets — all pass
- Inline style policy: No layout inline styles (H021 clean)

## Risks
- Low. Action POST handlers (Advance, Kill, Hold, Reactivate) are UI-only placeholders — wiring to pipeline service pending in a future PIPE.
- No migrations, no schema changes.

Closes: PIPE-4 (Build pipeline list and detail views + templates)