### PR TITLE
feat(pipeline): pipe-5 - add add-to-pipeline button to VRM list

### DIFF
--- a/core/templatetags/math_filters.py
+++ b/core/templatetags/math_filters.py
@@ -21,3 +21,12 @@ def mul(value, arg):
         return Decimal(str(value)) * Decimal(str(arg))
     except (ValueError, TypeError, InvalidOperation):
         return value
+
+
+@register.filter
+def get_item(dictionary, key):
+    """Look up a dictionary value by key. Usage: {{ dict|get_item:key }}."""
+    try:
+        return dictionary.get(key)
+    except (AttributeError, TypeError):
+        return None

--- a/core/urls.py
+++ b/core/urls.py
@@ -61,6 +61,11 @@ urlpatterns = [
     path("pipeline/list/", views.pipeline_list, name="pipeline_list"),
     path("pipeline/<int:pk>/", views.pipeline_detail, name="pipeline_detail"),
     path(
+        "pipeline/add-from-source/",
+        views.pipeline_add_from_source,
+        name="pipeline_add_from_source",
+    ),
+    path(
         "settings/investment-targets/",
         views.investment_targets_edit,
         name="investment_targets_edit",

--- a/core/views.py
+++ b/core/views.py
@@ -1207,6 +1207,55 @@ def pipeline_detail(request: HttpRequest, pk: int) -> HttpResponse:
     )
 
 
+@login_required
+def pipeline_add_from_source(request: HttpRequest) -> HttpResponse:
+    """POST-only view to add a source property to the user's pipeline.
+
+    POST params:
+      source_type: 'vrm' (future: 'foreclosure', 'listing')
+      source_id:   primary key / identifier of the source record
+      next:        redirect URL on error (default: /pipeline/list/)
+    """
+    from django.shortcuts import redirect
+
+    from core.services.pipeline import create_from_vrm
+
+    if request.method != "POST":
+        messages.error(request, "This endpoint requires POST")
+        return redirect("pipeline_list")
+
+    source_type = request.POST.get("source_type", "")
+    source_id = request.POST.get("source_id", "")
+    next_url = request.POST.get("next", redirect("pipeline_list").url)
+
+    if not source_type or not source_id:
+        messages.error(request, "Missing source_type or source_id")
+        return redirect(next_url)
+
+    if source_type == "vrm":
+        try:
+            vrm = VrmProperty.objects.get(vrm_property_id=int(source_id))
+        except (VrmProperty.DoesNotExist, ValueError, TypeError):
+            messages.error(request, "VRM property not found")
+            return redirect(next_url)
+
+        pp, created = create_from_vrm(vrm, request.user)
+
+        if created:
+            verdict = "passed" if pp.screening_passed else "failed"
+            messages.success(
+                request,
+                f"VRM property added to pipeline. Screening {verdict}.",
+            )
+        else:
+            messages.info(request, "Already in your pipeline")
+
+        return redirect("pipeline_detail", pk=pp.pk)
+
+    messages.error(request, f"Unknown source type: {source_type}")
+    return redirect(next_url)
+
+
 def search_listings(request):
     # Optionally load a saved search to prefill filters
     saved_id = request.GET.get("saved_id")
@@ -1660,6 +1709,19 @@ def vrm_properties_list(request: HttpRequest) -> HttpResponse:
         queryset = queryset.filter(zip_code=zip_code)
     queryset = queryset.order_by("-last_seen_at")[:100]
 
+    # Annotate with pipeline membership (dict: source_id → pipeline_pk)
+    from core.models import PipelineProperty
+
+    if request.user.is_authenticated:
+        user_pipeline_entries = {
+            str(pp.source_id): pp.pk
+            for pp in PipelineProperty.objects.filter(
+                user=request.user, source_type=PipelineProperty.SourceType.VRM
+            )
+        }
+    else:
+        user_pipeline_entries = {}
+
     return render(
         request,
         "vrm_properties/list.html",
@@ -1671,6 +1733,7 @@ def vrm_properties_list(request: HttpRequest) -> HttpResponse:
             "total_count": VrmProperty.objects.count(),
             "filtered_count": queryset.count(),
             "pipeline_message": pipeline_message,
+            "pipeline_entries": user_pipeline_entries,
         },
     )
 

--- a/static/css/pipeline.css
+++ b/static/css/pipeline.css
@@ -421,3 +421,29 @@
   gap: var(--sp-2);
   justify-content: flex-end;
 }
+
+/* ── VRM list add-to-pipeline button ──────────────────────────────── */
+.pipeline-add-btn {
+  font-size: var(--text-xs);
+  padding: 2px var(--sp-2);
+  border-radius: var(--radius-sm);
+  background: var(--color-primary);
+  color: white;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.pipeline-in-link {
+  font-size: var(--text-xs);
+  padding: 2px var(--sp-2);
+  border-radius: var(--radius-sm);
+  background: var(--color-verdict-a-bg);
+  color: var(--color-verdict-a-text);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.pipeline-inline-form {
+  margin: 0;
+}

--- a/templates/vrm_properties/list.html
+++ b/templates/vrm_properties/list.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
+{% load static %}
+{% load math_filters %}
 {% block title %}VRM Properties{% endblock %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'css/pipeline.css' %}">
+{% endblock %}
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
@@ -84,6 +90,7 @@
         <th>Status</th>
         <th>Vendee</th>
         <th>Scraped</th>
+        <th>Pipeline</th>
       </tr>
     </thead>
     <tbody>
@@ -116,6 +123,25 @@
         </td>
         <td>{% if prop.vendee_eligible %}<span class="badge bg-primary">Yes</span>{% else %}-{% endif %}</td>
         <td>{{ prop.last_seen_at|date:"M d, Y" }}</td>
+        <td>
+          {% with pp_id=prop.vrm_property_id|stringformat:"s" %}
+          {% if pp_id in pipeline_entries %}
+            <a href="{% url 'pipeline_detail' pipeline_entries|get_item:pp_id %}" class="pipeline-in-link">
+              In Pipeline &rarr;
+            </a>
+          {% else %}
+          <form method="post" action="{% url 'pipeline_add_from_source' %}" class="pipeline-inline-form">
+            {% csrf_token %}
+            <input type="hidden" name="source_type" value="vrm">
+            <input type="hidden" name="source_id" value="{{ prop.vrm_property_id }}">
+            <input type="hidden" name="next" value="{% url 'vrm_properties_list' %}{% if selected_state %}?state={{ selected_state }}{% endif %}">
+            <button type="submit" class="pipeline-add-btn">
+              + Add to Pipeline
+            </button>
+          </form>
+          {% endif %}
+          {% endwith %}
+        </td>
       </tr>
       {% endfor %}
     </tbody>

--- a/tests/test_add_to_pipeline.py
+++ b/tests/test_add_to_pipeline.py
@@ -1,0 +1,147 @@
+"""Tests for PIPE-5: Add to Pipeline from VRM list view.
+
+Tests cover:
+- Adding VRM property creates PipelineProperty, runs screening, redirects
+- Adding same VRM property twice returns existing record, no duplicate
+- POST only — GET returns error
+- Unknown source_type returns error
+- Missing source_id returns error
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+from django.utils import timezone
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="pipe5",
+        email="pipe5@test.com",
+        password="testpass123",
+    )
+
+
+@pytest.fixture
+def client(db, user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+@pytest.fixture
+def vrm_property(db):
+    """VrmProperty fixture for add-to-pipeline tests."""
+    from core.models import VrmProperty as VP
+
+    now = timezone.now()
+    vp = VP(
+        vrm_property_id=5001,
+        vrm_listing_url="https://example.com/5001",
+        address="5001 Pipeline Ave",
+        city="Austin",
+        state="TX",
+        zip_code="78701",
+        list_price=Decimal("250000"),
+        projected_monthly_rent=Decimal("2000"),
+        bedrooms=3,
+        year_built=2010,
+        property_type="single-family",
+        status=VP.Status.FOR_SALE,
+        scraped_at=now,
+        last_seen_at=now,
+    )
+    vp.save()
+    return vp
+
+
+class TestAddToPipelineView:
+    URL = reverse("pipeline_add_from_source")
+
+    def test_requires_login(self, db, vrm_property):
+        """Anonymous users are redirected to login."""
+        c = Client()
+        resp = c.post(
+            self.URL,
+            {"source_type": "vrm", "source_id": "5001"},
+        )
+        assert resp.status_code == 302
+        assert "/login/" in resp.url
+
+    def test_get_returns_error(self, client):
+        """GET request returns error and redirects to pipeline_list."""
+        resp = client.get(self.URL)
+        assert resp.status_code == 302
+        assert "/pipeline/list/" in resp.url
+
+    def test_adds_vrm_to_pipeline(self, client, user, vrm_property):
+        """POST with valid source creates PipelineProperty and redirects to detail."""
+        from core.models import PipelineProperty
+
+        resp = client.post(
+            self.URL,
+            {"source_type": "vrm", "source_id": "5001"},
+        )
+        # Should redirect to pipeline_detail
+        assert resp.status_code == 302
+        detail_url = reverse("pipeline_detail", kwargs={"pk": 1})
+        assert detail_url in resp.url
+
+        # PipelineProperty should exist
+        pp = PipelineProperty.objects.get(user=user, source_type="vrm")
+        assert pp.source_id == "5001"
+        assert pp.stage == "SCREENING"  # create_from_vrm runs screening
+        assert pp.screening_passed is not None
+
+    def test_duplicate_returns_existing(self, client, user, vrm_property):
+        """Adding same VRM property twice returns existing record."""
+        from core.models import PipelineProperty
+
+        # First add
+        client.post(self.URL, {"source_type": "vrm", "source_id": "5001"})
+        count_after_first = PipelineProperty.objects.count()
+
+        # Second add
+        resp = client.post(self.URL, {"source_type": "vrm", "source_id": "5001"})
+        count_after_second = PipelineProperty.objects.count()
+
+        assert count_after_first == 1
+        assert count_after_second == 1  # No duplicate
+        assert resp.status_code == 302
+
+        # Should redirect to existing detail page
+        pp = PipelineProperty.objects.get(user=user, source_type="vrm")
+        detail_url = reverse("pipeline_detail", kwargs={"pk": pp.pk})
+        assert detail_url in resp.url
+
+    def test_unknown_source_type(self, client):
+        """Unknown source_type returns error and redirects."""
+        resp = client.post(
+            self.URL,
+            {"source_type": "bogus", "source_id": "1"},
+        )
+        assert resp.status_code == 302
+
+    def test_missing_source_id(self, client):
+        """Missing source_id returns error and redirects."""
+        resp = client.post(
+            self.URL,
+            {"source_type": "vrm", "source_id": ""},
+        )
+        assert resp.status_code == 302
+
+    def test_nonexistent_vrm_id(self, client):
+        """Nonexistent VRM ID returns error and redirects."""
+        resp = client.post(
+            self.URL,
+            {"source_type": "vrm", "source_id": "999999"},
+        )
+        assert resp.status_code == 302


### PR DESCRIPTION
## Problem

VRM property list has no way to add properties to the user's acquisition pipeline. Users must manually navigate elsewhere to create PipelineProperty entries.

## Solution

### pipeline_add_from_source view (POST-only)
- Accepts source_type=vrm and source_id
- Calls create_from_vrm() which creates PipelineProperty + runs screening
- On first add: redirects to pipeline_detail with success message showing screening verdict
- On duplicate: redirects to existing pipeline_detail with 'Already in your pipeline' info
- On error: redirects back with error message

### VRM list template changes
- Added Pipeline column to the table (header + cell per row)
- '+ Add to Pipeline' button for properties not yet in pipeline
- 'In Pipeline →' link to detail page for already-added properties
- Pipeline membership annotated via a single extra query (Option A: dict of source_id→pk)

### Template filter
- Added get_item filter to math_filters for dict key lookup in templates

## Validation
- `python -m pytest tests/test_add_to_pipeline.py`: **7 passed**
- `python -m pytest tests/test_add_to_pipeline.py tests/test_pipeline_service.py tests/test_screening.py -q`: **74 passed**
- Pre-commit: ruff, mypy, djlint, commitizen, bandit, secrets — all pass

## Risks
- Low. No migrations. POST-only endpoint (GET returns redirect).
- Only VRM source type supported; foreclosure/listing source types are future work.

Closes: PIPE-5 (Add Add to Pipeline button to VRM list view)