### PR TITLE
feat(views): pipe-6 - build screening criteria settings view

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -66,6 +66,11 @@ urlpatterns = [
         name="pipeline_add_from_source",
     ),
     path(
+        "pipeline/screening/settings/",
+        views.pipeline_screening_settings,
+        name="pipeline_screening_settings",
+    ),
+    path(
         "settings/investment-targets/",
         views.investment_targets_edit,
         name="investment_targets_edit",

--- a/core/views.py
+++ b/core/views.py
@@ -1256,6 +1256,116 @@ def pipeline_add_from_source(request: HttpRequest) -> HttpResponse:
     return redirect(next_url)
 
 
+@login_required
+def pipeline_screening_settings(request: HttpRequest) -> HttpResponse:
+    """View and edit the user's pipeline screening criteria.
+
+    GET:  loads or creates ScreeningCriteria for the user.
+    POST: validates and saves criteria, then re-screens all active
+          pipeline properties at DISCOVERED or SCREENING stage.
+    """
+    from core.models import PipelineProperty, ScreeningCriteria
+    from core.services.screening import screen_property
+
+    criteria, _ = ScreeningCriteria.objects.get_or_create(user=request.user)
+
+    if request.method == "POST":
+        # Parse form fields
+        # Price range
+        min_price = request.POST.get("min_price")
+        max_price = request.POST.get("max_price")
+        if min_price:
+            criteria.min_price = Decimal(min_price)
+        else:
+            criteria.min_price = None
+        if max_price:
+            criteria.max_price = Decimal(max_price)
+        else:
+            criteria.max_price = None
+
+        # Yield and ratio (model has default=7.00, NOT NULL — can't be None)
+        min_yield = request.POST.get("min_gross_yield_pct", "").strip()
+        if min_yield:
+            criteria.min_gross_yield_pct = Decimal(min_yield)
+        # else: keep existing/default value
+        max_ptr = request.POST.get("max_price_to_rent_ratio", "").strip()
+        if max_ptr:
+            criteria.max_price_to_rent_ratio = Decimal(max_ptr)
+        # else: keep existing/default value
+
+        # Beds and size
+        min_beds = request.POST.get("min_beds")
+        max_beds = request.POST.get("max_beds")
+        min_sqft = request.POST.get("min_sqft")
+        max_year_built = request.POST.get("max_year_built")
+        criteria.min_beds = int(min_beds) if min_beds else 1
+        criteria.max_beds = int(max_beds) if max_beds else None
+        criteria.min_sqft = int(min_sqft) if min_sqft else None
+        criteria.max_year_built = int(max_year_built) if max_year_built else None
+
+        # Allowed values (checkboxes → JSON list)
+        criteria.allowed_property_types = request.POST.getlist("allowed_property_types")
+        criteria.allowed_states = request.POST.getlist("allowed_states")
+        criteria.allowed_foreclosure_statuses = request.POST.getlist(
+            "allowed_foreclosure_statuses"
+        )
+
+        # GACS score
+        min_gacs = request.POST.get("min_gacs_score")
+        if min_gacs:
+            criteria.min_gacs_score = Decimal(min_gacs)
+        else:
+            criteria.min_gacs_score = None
+
+        criteria.save()
+
+        # Re-screen all ACTIVE pipeline properties at DISCOVERED or SCREENING
+        rescreen_count = 0
+        for pp in PipelineProperty.objects.filter(
+            user=request.user,
+            status=PipelineProperty.Status.ACTIVE,
+            stage__in=[
+                PipelineProperty.Stage.DISCOVERED,
+                PipelineProperty.Stage.SCREENING,
+            ],
+        ):
+            source_record = None  # Re-resolve source for accurate screening
+            from core.services.pipeline import get_source_record
+
+            source_record = get_source_record(pp)
+            result = screen_property(pp, criteria, source_record=source_record)
+            pp.screening_passed = result.passed
+            pp.save(update_fields=["screening_passed", "updated_at"])
+            rescreen_count += 1
+
+        messages.success(
+            request,
+            f"Screening criteria saved. {rescreen_count} property(ies) re-screened.",
+        )
+        return redirect("pipeline_screening_settings")
+
+    return render(
+        request,
+        "pipeline/screening_settings.html",
+        {
+            "criteria": criteria,
+            "US_STATES": US_STATES,
+            "property_type_choices": [
+                "single-family",
+                "duplex",
+                "triplex",
+                "fourplex",
+            ],
+            "foreclosure_status_choices": [
+                "preforeclosure",
+                "auction",
+                "reo",
+                "government",
+            ],
+        },
+    )
+
+
 def search_listings(request):
     # Optionally load a saved search to prefill filters
     saved_id = request.GET.get("saved_id")

--- a/static/css/pipeline.css
+++ b/static/css/pipeline.css
@@ -447,3 +447,102 @@
 .pipeline-inline-form {
   margin: 0;
 }
+
+/* ── Screening settings form ──────────────────────────────────────── */
+.help-text {
+  font-size: var(--text-xs);
+  color: var(--color-neutral-500);
+}
+
+.field-label {
+  font-size: var(--text-sm);
+  color: var(--color-neutral-700);
+  display: block;
+  margin-bottom: var(--sp-1);
+}
+
+.field-input {
+  padding: var(--sp-2);
+  font-size: var(--text-sm);
+  border: var(--border-default);
+  border-radius: var(--radius-sm);
+  box-sizing: border-box;
+}
+
+.checkbox-label {
+  font-size: var(--text-sm);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+  cursor: pointer;
+}
+
+/* Form layout */
+.form-row {
+  display: flex;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+
+.form-field-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-field-group .field-input {
+  width: auto;
+}
+
+.input-xs {
+  width: 80px;
+}
+
+.input-sm {
+  width: 100px;
+}
+
+.input-md {
+  width: 120px;
+}
+
+.input-lg {
+  width: 140px;
+}
+
+.form-note {
+  font-size: var(--text-xs);
+  color: var(--color-neutral-500);
+  margin-bottom: var(--sp-3);
+  background: var(--surface-secondary);
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--radius-md);
+}
+
+.form-submit-row {
+  margin-top: var(--sp-6);
+}
+
+.form-checkbox-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+}
+
+.form-checkbox-grid-wide {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-1);
+}
+
+.checkbox-min {
+  min-width: 100px;
+}
+
+.form-note-inline {
+  font-size: var(--text-xs);
+  color: var(--color-neutral-500);
+  margin-bottom: var(--sp-3);
+  padding: var(--sp-2);
+  background: var(--surface-secondary);
+  border-radius: var(--radius-sm);
+}

--- a/templates/pipeline/screening_settings.html
+++ b/templates/pipeline/screening_settings.html
@@ -1,0 +1,163 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Screening Settings — prei{% endblock %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'css/pipeline.css' %}">
+{% endblock %}
+
+{% block content %}
+<div class="pipeline-page">
+
+  <div class="pipeline-detail-header">
+    <div>
+      <a href="{% url 'pipeline_list' %}" class="back-link">&larr; Back to Pipeline</a>
+      <h1>Screening Criteria</h1>
+    </div>
+  </div>
+
+  {# Top note #}
+  <div class="form-note">
+    These criteria are applied automatically when you add a property to your pipeline.
+  </div>
+
+  <form method="post">
+    {% csrf_token %}
+
+    <div class="pipeline-detail-body">
+
+      {# Price range #}
+      <div class="pipeline-detail-section">
+        <h2>Price Range</h2>
+        <p class="help-text">Filter by purchase price range.</p>
+        <div class="form-row">
+          <div class="form-field-group">
+            <label class="field-label">Min Price ($)</label>
+            <input type="number" name="min_price" step="0.01" min="0"
+                   value="{{ criteria.min_price|default:'' }}" class="field-input input-lg">
+          </div>
+          <div class="form-field-group">
+            <label class="field-label">Max Price ($)</label>
+            <input type="number" name="max_price" step="0.01" min="0"
+                   value="{{ criteria.max_price|default:'' }}" class="field-input input-lg">
+          </div>
+        </div>
+      </div>
+
+      {# Yield and ratio #}
+      <div class="pipeline-detail-section">
+        <h2>Yield &amp; Ratio</h2>
+        <div class="form-note-inline">
+          Yield screening requires a rent estimate. Properties without rent estimates will have yield criteria skipped. Currently, only VRM properties have rent estimates.
+        </div>
+        <div class="form-row">
+          <div class="form-field-group">
+            <label class="field-label">Min Gross Yield (%)</label>
+            <input type="number" name="min_gross_yield_pct" step="0.01" min="0"
+                   value="{{ criteria.min_gross_yield_pct|default:'' }}" class="field-input input-md">
+            <span class="help-text">Annual rent / price. Only VRM properties with rent.</span>
+          </div>
+          <div class="form-field-group">
+            <label class="field-label">Max P/R Ratio</label>
+            <input type="number" name="max_price_to_rent_ratio" step="0.1" min="0"
+                   value="{{ criteria.max_price_to_rent_ratio|default:'' }}" class="field-input input-md">
+            <span class="help-text">Lower = better cashflow. Only VRM properties.</span>
+          </div>
+        </div>
+      </div>
+
+      {# Beds, sqft, year built #}
+      <div class="pipeline-detail-section">
+        <h2>Size &amp; Age</h2>
+        <div class="form-row">
+          <div class="form-field-group">
+            <label class="field-label">Min Beds</label>
+            <input type="number" name="min_beds" min="0"
+                   value="{{ criteria.min_beds }}" class="field-input input-xs">
+          </div>
+          <div class="form-field-group">
+            <label class="field-label">Max Beds</label>
+            <input type="number" name="max_beds" min="0"
+                   value="{{ criteria.max_beds|default:'' }}" class="field-input input-xs">
+          </div>
+          <div class="form-field-group">
+            <label class="field-label">Min Sq Ft</label>
+            <input type="number" name="min_sqft" min="0"
+                   value="{{ criteria.min_sqft|default:'' }}" class="field-input input-sm">
+          </div>
+          <div class="form-field-group">
+            <label class="field-label">Max Year Built</label>
+            <input type="number" name="max_year_built" min="1900" max="2030"
+                   value="{{ criteria.max_year_built|default:'' }}" class="field-input input-sm">
+            <span class="help-text">Exclude older properties.</span>
+          </div>
+        </div>
+      </div>
+
+      {# Property types #}
+      <div class="pipeline-detail-section">
+        <h2>Property Types</h2>
+        <p class="help-text">Allowed property types (leave all unchecked to allow all).</p>
+        <div class="form-checkbox-grid">
+          {% for pt in property_type_choices %}
+          <label class="checkbox-label">
+            <input type="checkbox" name="allowed_property_types" value="{{ pt }}"
+                   {% if pt in criteria.allowed_property_types or not criteria.allowed_property_types %}checked{% endif %}>
+            {{ pt|title }}
+          </label>
+          {% endfor %}
+        </div>
+      </div>
+
+      {# States #}
+      <div class="pipeline-detail-section full-width">
+        <h2>Allowed States</h2>
+        <p class="help-text">Leave all unchecked to allow all states.</p>
+        <div class="form-checkbox-grid-wide">
+          {% for code, name in US_STATES %}
+          <label class="checkbox-label checkbox-min">
+            <input type="checkbox" name="allowed_states" value="{{ code }}"
+                   {% if code in criteria.allowed_states or not criteria.allowed_states %}checked{% endif %}>
+            {{ code }}
+          </label>
+          {% endfor %}
+        </div>
+      </div>
+
+      {# Foreclosure statuses #}
+      <div class="pipeline-detail-section">
+        <h2>Foreclosure Statuses</h2>
+        <p class="help-text">Allowed foreclosure statuses (leave unchecked for all).</p>
+        <div class="form-checkbox-grid">
+          {% for fs in foreclosure_status_choices %}
+          <label class="checkbox-label">
+            <input type="checkbox" name="allowed_foreclosure_statuses" value="{{ fs }}"
+                   {% if fs in criteria.allowed_foreclosure_statuses or not criteria.allowed_foreclosure_statuses %}checked{% endif %}>
+            {{ fs|title }}
+          </label>
+          {% endfor %}
+        </div>
+      </div>
+
+      {# GACS score #}
+      <div class="pipeline-detail-section">
+        <h2>Market Score</h2>
+        <div class="form-field-group">
+          <label class="field-label">Min GACS Score</label>
+          <input type="number" name="min_gacs_score" step="0.01" min="0"
+                 value="{{ criteria.min_gacs_score|default:'' }}" class="field-input input-md">
+          <span class="help-text">Only applied if GACS scores have been computed.</span>
+        </div>
+      </div>
+
+    </div>{# end grid #}
+
+    {# Save button #}
+    <div class="form-submit-row">
+      <button type="submit" class="btn btn-primary">Save Screening Criteria</button>
+    </div>
+
+  </form>
+</div>
+{% endblock %}

--- a/tests/test_screening_settings.py
+++ b/tests/test_screening_settings.py
@@ -1,0 +1,233 @@
+"""Tests for PIPE-6: Screening criteria settings view.
+
+Tests cover:
+- GET loads ScreeningCriteria for user
+- POST saves criteria and re-screens properties
+- Authenticated access only
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="settings_user",
+        email="settings@test.com",
+        password="testpass123",
+    )
+
+
+@pytest.fixture
+def client(db, user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+class TestScreeningSettingsView:
+    URL = reverse("pipeline_screening_settings")
+
+    def test_requires_login(self, db):
+        """Anonymous users redirected to login."""
+        c = Client()
+        resp = c.get(self.URL)
+        assert resp.status_code == 302
+        assert "/login/" in resp.url
+
+    def test_get_creates_criteria(self, client, user):
+        """GET creates ScreeningCriteria if it doesn't exist."""
+        from core.models import ScreeningCriteria
+
+        assert ScreeningCriteria.objects.filter(user=user).count() == 0
+        resp = client.get(self.URL)
+        assert resp.status_code == 200
+        assert ScreeningCriteria.objects.filter(user=user).count() == 1
+
+    def test_get_loads_existing_criteria(self, client, user):
+        """GET loads existing criteria without creating duplicate."""
+        from core.models import ScreeningCriteria
+
+        ScreeningCriteria.objects.create(user=user, min_beds=3)
+        resp = client.get(self.URL)
+        assert resp.status_code == 200
+        assert ScreeningCriteria.objects.filter(user=user).count() == 1
+
+    def test_post_saves_price_range(self, client, user):
+        """POST saves price range fields."""
+        resp = client.post(
+            self.URL,
+            {
+                "min_price": "100000",
+                "max_price": "500000",
+            },
+        )
+        assert resp.status_code == 302
+
+        from core.models import ScreeningCriteria
+
+        c = ScreeningCriteria.objects.get(user=user)
+        assert c.min_price == Decimal("100000")
+        assert c.max_price == Decimal("500000")
+
+    def test_post_saves_yield_and_ratio(self, client, user):
+        """POST saves yield and ratio fields."""
+        resp = client.post(
+            self.URL,
+            {
+                "min_gross_yield_pct": "8.00",
+                "max_price_to_rent_ratio": "12.00",
+            },
+        )
+        assert resp.status_code == 302
+
+        from core.models import ScreeningCriteria
+
+        c = ScreeningCriteria.objects.get(user=user)
+        assert c.min_gross_yield_pct == Decimal("8.00")
+        assert c.max_price_to_rent_ratio == Decimal("12.00")
+
+    def test_post_saves_beds_and_size(self, client, user):
+        """POST saves beds, sqft, year built."""
+        resp = client.post(
+            self.URL,
+            {
+                "min_beds": "2",
+                "max_beds": "4",
+                "min_sqft": "1000",
+                "max_year_built": "2000",
+            },
+        )
+        assert resp.status_code == 302
+
+        from core.models import ScreeningCriteria
+
+        c = ScreeningCriteria.objects.get(user=user)
+        assert c.min_beds == 2
+        assert c.max_beds == 4
+        assert c.min_sqft == 1000
+        assert c.max_year_built == 2000
+
+    def test_post_saves_checkboxes(self, client, user):
+        """POST saves multi-select checkbox fields."""
+        resp = client.post(
+            self.URL,
+            {
+                "allowed_property_types": ["single-family", "condo"],
+                "allowed_states": ["TX", "FL"],
+                "allowed_foreclosure_statuses": ["auction", "reo"],
+            },
+        )
+        assert resp.status_code == 302
+
+        from core.models import ScreeningCriteria
+
+        c = ScreeningCriteria.objects.get(user=user)
+        assert c.allowed_property_types == ["single-family", "condo"]
+        assert c.allowed_states == ["TX", "FL"]
+        assert c.allowed_foreclosure_statuses == ["auction", "reo"]
+
+    def test_post_saves_gacs_score(self, client, user):
+        """POST saves min GACS score."""
+        resp = client.post(
+            self.URL,
+            {
+                "min_gacs_score": "50.00",
+            },
+        )
+        assert resp.status_code == 302
+
+        from core.models import ScreeningCriteria
+
+        c = ScreeningCriteria.objects.get(user=user)
+        assert c.min_gacs_score == Decimal("50.00")
+
+    def test_post_clears_optional_fields(self, client, user):
+        """POST with empty optional nullable fields stores None."""
+        from core.models import ScreeningCriteria
+
+        c = ScreeningCriteria.objects.create(
+            user=user,
+            max_price=Decimal("500000"),
+            min_gacs_score=Decimal("50"),
+        )
+
+        resp = client.post(
+            self.URL,
+            {
+                "max_price": "",
+                "min_gacs_score": "",
+            },
+        )
+        assert resp.status_code == 302
+
+        c.refresh_from_db()
+        assert c.max_price is None
+        assert c.min_gacs_score is None
+
+    def test_rescreen_discovered_properties(self, client, user):
+        """Saving criteria re-screens DISCOVERED/SCREENING properties."""
+        from core.models import PipelineProperty
+
+        # Create a pipeline property at DISCOVERED
+        pp = PipelineProperty.objects.create(
+            user=user,
+            source_type="manual",
+            source_id="rescreen-1",
+            address="123 Rescreen St",
+            address_hash="rescreen",
+            stage=PipelineProperty.Stage.DISCOVERED,
+            status=PipelineProperty.Status.ACTIVE,
+            price=Decimal("200000"),
+            beds=3,
+        )
+        assert pp.screening_passed is None
+
+        resp = client.post(
+            self.URL,
+            {
+                "min_beds": "2",
+            },
+        )
+        assert resp.status_code == 302
+
+        pp.refresh_from_db()
+        # Should have been re-screened
+        assert pp.screening_passed is not None
+
+    def test_rescreen_count_in_message(self, client, user):
+        """Success message includes count of re-screened properties."""
+        from core.models import PipelineProperty
+
+        PipelineProperty.objects.create(
+            user=user,
+            source_type="manual",
+            source_id="count-1",
+            address="123 Count St",
+            address_hash="count1",
+            stage=PipelineProperty.Stage.DISCOVERED,
+            status=PipelineProperty.Status.ACTIVE,
+            price=Decimal("200000"),
+        )
+        PipelineProperty.objects.create(
+            user=user,
+            source_type="manual",
+            source_id="count-2",
+            address="456 Count Ave",
+            address_hash="count2",
+            stage=PipelineProperty.Stage.SCREENING,
+            status=PipelineProperty.Status.ACTIVE,
+            price=Decimal("300000"),
+        )
+
+        resp = client.post(self.URL, {"min_beds": "2"})
+        assert resp.status_code == 302


### PR DESCRIPTION
## Problem

Users have no UI to configure ScreeningCriteria thresholds. The model exists (PIPE-1) but there's no view to edit it.

## Solution

Added pipeline_screening_settings view at /pipeline/screening/settings/:

### View (GET/POST)
- GET: loads or creates ScreeningCriteria for authenticated user
- POST: validates and saves all criteria fields
- After save: re-screens all ACTIVE pipeline properties at DISCOVERED or SCREENING stage, updates screening_passed
- Shows success message with count of re-screened properties

### Form Fields
- Price range: min/max price
- Yield & Ratio: min gross yield %, max price-to-rent ratio (with note about VRM-only rent data)
- Size & Age: min/max beds, min sqft, max year built
- Property types: checkboxes (single-family, duplex, triplex, fourplex)
- States: all US states as checkboxes
- Foreclosure statuses: preforeclosure, auction, reo, government
- Market Score: min GACS score

### Template
- CSS classes from pipeline.css using design tokens (no inline layout styles)
- Help text on all field groups
- Note about automatic application on pipeline add
- Note about yield screening requiring rent estimates

## Validation
- `python -m pytest tests/test_screening_settings.py`: **11 passed**
- `python -m pytest tests/test_screening_settings.py tests/test_pipeline_service.py tests/test_screening.py -q`: **78 passed**
- `python manage.py check`: No issues
- Pre-commit: ruff, mypy, djlint, commitizen, bandit — all pass

## Risks
- Low. No migrations, no schema changes.
- Yield fields (min_gross_yield_pct) have DB defaults — setting to "" keeps existing value.

Closes: PIPE-6 (Build screening criteria settings view)