### PR TITLE
feat(views): pipe-8 - build offer, dd, and renovation forms and views

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -71,6 +71,21 @@ urlpatterns = [
         name="pipeline_screening_settings",
     ),
     path(
+        "pipeline/<int:pk>/offer/",
+        views.pipeline_offer_create,
+        name="pipeline_offer_create",
+    ),
+    path(
+        "pipeline/<int:pk>/dd/",
+        views.pipeline_dd_checklist,
+        name="pipeline_dd_checklist",
+    ),
+    path(
+        "pipeline/<int:pk>/renovation/",
+        views.pipeline_renovation,
+        name="pipeline_renovation",
+    ),
+    path(
         "settings/investment-targets/",
         views.investment_targets_edit,
         name="investment_targets_edit",

--- a/core/views.py
+++ b/core/views.py
@@ -1366,6 +1366,155 @@ def pipeline_screening_settings(request: HttpRequest) -> HttpResponse:
     )
 
 
+@login_required
+def pipeline_offer_create(request: HttpRequest, pk: int) -> HttpResponse:
+    """Create or list offers for a pipeline property."""
+    from core.models import OfferRecord, PipelineProperty
+
+    try:
+        prop = PipelineProperty.objects.get(pk=pk, user=request.user)
+    except PipelineProperty.DoesNotExist:
+        raise Http404
+
+    existing_offers = OfferRecord.objects.filter(pipeline_property=prop).order_by(
+        "-created_at"
+    )
+
+    if request.method == "POST":
+        from datetime import date
+
+        offer_price = request.POST.get("offer_price")
+        offer_date = request.POST.get("offer_date", str(date.today()))
+        offer_expiry = request.POST.get("offer_expiry") or None
+        contingencies = request.POST.getlist("contingencies")
+        notes = request.POST.get("notes", "")
+
+        if not offer_price:
+            messages.error(request, "Offer price is required.")
+            return redirect("pipeline_offer_create", pk=pk)
+
+        OfferRecord.objects.create(
+            pipeline_property=prop,
+            offer_price=Decimal(offer_price),
+            offer_date=offer_date,
+            offer_expiry=offer_expiry,
+            contingencies=contingencies,
+            notes=notes,
+        )
+        messages.success(request, "Offer recorded.")
+        return redirect("pipeline_offer_create", pk=pk)
+
+    return render(
+        request,
+        "pipeline/offer_form.html",
+        {
+            "prop": prop,
+            "offers": existing_offers,
+        },
+    )
+
+
+@login_required
+def pipeline_dd_checklist(request: HttpRequest, pk: int) -> HttpResponse:
+    """View and edit due diligence checklist for a pipeline property."""
+    from core.models import DueDiligenceChecklist, PipelineProperty
+    from core.services.pipeline import kill_property
+
+    try:
+        prop = PipelineProperty.objects.get(pk=pk, user=request.user)
+    except PipelineProperty.DoesNotExist:
+        raise Http404
+
+    dd, created = DueDiligenceChecklist.objects.get_or_create(
+        pipeline_property=prop,
+    )
+
+    if request.method == "POST":
+        dd.inspection_scheduled = "inspection_scheduled" in request.POST
+        dd.inspection_completed = "inspection_completed" in request.POST
+        dd.inspection_findings = request.POST.get("inspection_findings", "")
+        dd.title_search_ordered = "title_search_ordered" in request.POST
+        dd.title_clear = (
+            True
+            if "title_clear" in request.POST
+            else (False if "title_clear_no" in request.POST else None)
+        )
+        dd.appraisal_ordered = "appraisal_ordered" in request.POST
+        appraisal_val = request.POST.get("appraisal_value", "").strip()
+        dd.appraisal_value = Decimal(appraisal_val) if appraisal_val else None
+        dd.insurance_quoted = "insurance_quoted" in request.POST
+        insurance_cost = request.POST.get("insurance_annual_cost", "").strip()
+        dd.insurance_annual_cost = Decimal(insurance_cost) if insurance_cost else None
+        dd.contractor_estimate_obtained = "contractor_estimate_obtained" in request.POST
+        contractor_est = request.POST.get("contractor_estimate_amount", "").strip()
+        dd.contractor_estimate_amount = (
+            Decimal(contractor_est) if contractor_est else None
+        )
+        dd.go_no_go = request.POST.get("go_no_go", "pending")
+        dd.no_go_reason = request.POST.get("no_go_reason", "")
+        dd.save()
+
+        if dd.go_no_go == "no_go" and dd.no_go_reason:
+            kill_property(prop, dd.no_go_reason)
+            messages.success(request, "Property killed due to DD findings.")
+        else:
+            messages.success(request, "Due diligence checklist saved.")
+
+        return redirect("pipeline_dd_checklist", pk=pk)
+
+    return render(
+        request,
+        "pipeline/dd_checklist.html",
+        {
+            "prop": prop,
+            "dd": dd,
+        },
+    )
+
+
+@login_required
+def pipeline_renovation(request: HttpRequest, pk: int) -> HttpResponse:
+    """View and edit renovation record for a pipeline property."""
+    from core.models import PipelineProperty, RenovationRecord
+
+    try:
+        prop = PipelineProperty.objects.get(pk=pk, user=request.user)
+    except PipelineProperty.DoesNotExist:
+        raise Http404
+
+    renovation, created = RenovationRecord.objects.get_or_create(
+        pipeline_property=prop,
+    )
+
+    if request.method == "POST":
+        est_budget = request.POST.get("estimated_budget", "").strip()
+        if est_budget:
+            renovation.estimated_budget = Decimal(est_budget)
+        start_date = request.POST.get("start_date", "").strip()
+        renovation.start_date = start_date or None
+        renovation.contractor = request.POST.get("contractor", "")
+        renovation.scope_of_work = request.POST.get("scope_of_work", "")
+        renovation.status = request.POST.get("status", "not_started")
+        completion_date = request.POST.get("completion_date", "").strip()
+        renovation.completion_date = completion_date or None
+        actual_cost = request.POST.get("actual_cost", "").strip()
+        renovation.actual_cost = Decimal(actual_cost) if actual_cost else None
+        renovation.notes = request.POST.get("notes", "")
+        renovation.save()
+
+        messages.success(request, "Renovation record saved.")
+        return redirect("pipeline_renovation", pk=pk)
+
+    return render(
+        request,
+        "pipeline/renovation_form.html",
+        {
+            "prop": prop,
+            "renovation": renovation,
+        },
+    )
+
+
 def search_listings(request):
     # Optionally load a saved search to prefill filters
     saved_id = request.GET.get("saved_id")

--- a/static/css/pipeline.css
+++ b/static/css/pipeline.css
@@ -546,3 +546,25 @@
   background: var(--surface-secondary);
   border-radius: var(--radius-sm);
 }
+
+/* Form spacing */
+.form-field-group {
+  margin-top: 0;
+}
+
+.mt-2 {
+  margin-top: var(--sp-2);
+}
+
+.mt-3 {
+  margin-top: var(--sp-3);
+}
+
+.input-full {
+  width: 100%;
+}
+
+.textarea-full {
+  width: 100%;
+  resize: vertical;
+}

--- a/templates/pipeline/dd_checklist.html
+++ b/templates/pipeline/dd_checklist.html
@@ -1,0 +1,136 @@
+{% extends "base.html" %}
+
+{% block title %}Due Diligence — {{ prop.address|truncatechars:30 }} — prei{% endblock %}
+
+{% block content %}
+<div class="pipeline-page">
+
+  <div class="pipeline-detail-header">
+    <div>
+      <a href="{% url 'pipeline_detail' prop.pk %}" class="back-link">&larr; Back to Property</a>
+      <h1>Due Diligence Checklist</h1>
+      <p class="help-text">{{ prop.address }}</p>
+    </div>
+  </div>
+
+  <form method="post">
+    {% csrf_token %}
+
+    <div class="pipeline-detail-body">
+
+      {# Inspection #}
+      <div class="pipeline-detail-section">
+        <h2>Inspection</h2>
+        <div class="form-checkbox-grid">
+          <label class="checkbox-label">
+            <input type="checkbox" name="inspection_scheduled" value="1" {% if dd.inspection_scheduled %}checked{% endif %}>
+            Inspection Scheduled
+          </label>
+          <label class="checkbox-label">
+            <input type="checkbox" name="inspection_completed" value="1" {% if dd.inspection_completed %}checked{% endif %}>
+            Inspection Completed
+          </label>
+        </div>
+        <div class="form-field-group mt-2">
+          <label class="field-label">Inspection Findings</label>
+          <textarea name="inspection_findings" rows="3" class="field-input input-full">{{ dd.inspection_findings }}</textarea>
+        </div>
+      </div>
+
+      {# Title #}
+      <div class="pipeline-detail-section">
+        <h2>Title</h2>
+        <div class="form-checkbox-grid">
+          <label class="checkbox-label">
+            <input type="checkbox" name="title_search_ordered" value="1" {% if dd.title_search_ordered %}checked{% endif %}>
+            Title Search Ordered
+          </label>
+          <label class="checkbox-label">
+            <input type="checkbox" name="title_clear" value="1" {% if dd.title_clear == True %}checked{% endif %}>
+            Title Clear
+          </label>
+          <label class="checkbox-label">
+            <input type="checkbox" name="title_clear_no" value="1" {% if dd.title_clear == False %}checked{% endif %}>
+            Title Issues Found
+          </label>
+        </div>
+      </div>
+
+      {# Appraisal #}
+      <div class="pipeline-detail-section">
+        <h2>Appraisal</h2>
+        <div class="form-checkbox-grid">
+          <label class="checkbox-label">
+            <input type="checkbox" name="appraisal_ordered" value="1" {% if dd.appraisal_ordered %}checked{% endif %}>
+            Appraisal Ordered
+          </label>
+        </div>
+        <div class="form-field-group mt-2">
+          <label class="field-label">Appraisal Value ($)</label>
+          <input type="number" name="appraisal_value" step="0.01" min="0"
+                 value="{{ dd.appraisal_value|default:'' }}" class="field-input input-lg">
+        </div>
+      </div>
+
+      {# Insurance #}
+      <div class="pipeline-detail-section">
+        <h2>Insurance</h2>
+        <div class="form-checkbox-grid">
+          <label class="checkbox-label">
+            <input type="checkbox" name="insurance_quoted" value="1" {% if dd.insurance_quoted %}checked{% endif %}>
+            Insurance Quoted
+          </label>
+        </div>
+        <div class="form-field-group mt-2">
+          <label class="field-label">Annual Insurance Cost ($)</label>
+          <input type="number" name="insurance_annual_cost" step="0.01" min="0"
+                 value="{{ dd.insurance_annual_cost|default:'' }}" class="field-input input-lg">
+        </div>
+      </div>
+
+      {# Contractor #}
+      <div class="pipeline-detail-section">
+        <h2>Contractor Estimate</h2>
+        <div class="form-checkbox-grid">
+          <label class="checkbox-label">
+            <input type="checkbox" name="contractor_estimate_obtained" value="1" {% if dd.contractor_estimate_obtained %}checked{% endif %}>
+            Estimate Obtained
+          </label>
+        </div>
+        <div class="form-field-group mt-2">
+          <label class="field-label">Estimate Amount ($)</label>
+          <input type="number" name="contractor_estimate_amount" step="0.01" min="0"
+                 value="{{ dd.contractor_estimate_amount|default:'' }}" class="field-input input-lg">
+        </div>
+      </div>
+
+      {# Go/No-Go decision (full width) #}
+      <div class="pipeline-detail-section full-width">
+        <h2>Go / No-Go Decision</h2>
+        <div class="form-row">
+          <label class="checkbox-label">
+            <input type="radio" name="go_no_go" value="pending" {% if dd.go_no_go == 'pending' %}checked{% endif %}>
+            Pending
+          </label>
+          <label class="checkbox-label">
+            <input type="radio" name="go_no_go" value="go" {% if dd.go_no_go == 'go' %}checked{% endif %}>
+            Go
+          </label>
+          <label class="checkbox-label">
+            <input type="radio" name="go_no_go" value="no_go" {% if dd.go_no_go == 'no_go' %}checked{% endif %}>
+            No Go
+          </label>
+        </div>
+        <div class="form-field-group mt-2">
+          <label class="field-label">No-Go Reason (required if No Go)</label>
+          <textarea name="no_go_reason" rows="2" class="field-input input-full">{{ dd.no_go_reason }}</textarea>
+        </div>
+        <div class="form-submit-row">
+          <button type="submit" class="btn btn-primary">Save Checklist</button>
+        </div>
+      </div>
+
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/templates/pipeline/offer_form.html
+++ b/templates/pipeline/offer_form.html
@@ -1,0 +1,92 @@
+{% extends "base.html" %}
+{% load humanize %}
+
+{% block title %}New Offer — {{ prop.address|truncatechars:30 }} — prei{% endblock %}
+
+{% block content %}
+<div class="pipeline-page">
+
+  <div class="pipeline-detail-header">
+    <div>
+      <a href="{% url 'pipeline_detail' prop.pk %}" class="back-link">&larr; Back to Property</a>
+      <h1>New Offer</h1>
+      <p class="help-text">{{ prop.address }} — {{ prop.stage|title }}</p>
+    </div>
+  </div>
+
+  <div class="pipeline-detail-body">
+
+    {# Offer form #}
+    <div class="pipeline-detail-section">
+      <h2>Offer Details</h2>
+      <form method="post">
+        {% csrf_token %}
+        <div class="form-row">
+          <div class="form-field-group">
+            <label class="field-label">Offer Price ($) *</label>
+            <input type="number" name="offer_price" step="0.01" min="0.01" required
+                   class="field-input input-lg">
+          </div>
+          <div class="form-field-group">
+            <label class="field-label">Offer Date</label>
+            <input type="date" name="offer_date" value="{{ 'now'|date:'Y-m-d' }}"
+                   class="field-input input-md">
+          </div>
+          <div class="form-field-group">
+            <label class="field-label">Offer Expiry</label>
+            <input type="date" name="offer_expiry" class="field-input input-md">
+          </div>
+        </div>
+
+        <div class="form-field-group mt-3">
+          <label class="field-label">Contingencies</label>
+          <div class="form-checkbox-grid">
+            <label class="checkbox-label">
+              <input type="checkbox" name="contingencies" value="inspection">
+              Inspection
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" name="contingencies" value="financing">
+              Financing
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" name="contingencies" value="appraisal">
+              Appraisal
+            </label>
+          </div>
+        </div>
+
+        <div class="form-field-group mt-3">
+          <label class="field-label">Notes</label>
+          <textarea name="notes" rows="3" class="field-input textarea-full"></textarea>
+        </div>
+
+        <div class="form-submit-row">
+          <button type="submit" class="btn btn-primary">Submit Offer</button>
+        </div>
+      </form>
+    </div>
+
+    {# Existing offers #}
+    <div class="pipeline-detail-section">
+      <h2>Existing Offers</h2>
+      {% if offers %}
+        <table class="pipeline-detail-table">
+          <tr><td>Date</td><td>Amount</td><td>Status</td><td>Expiry</td></tr>
+          {% for offer in offers %}
+          <tr>
+            <td>{{ offer.offer_date|date:"M j, Y" }}</td>
+            <td>${{ offer.offer_price|floatformat:2|intcomma }}</td>
+            <td>{{ offer.get_status_display }}</td>
+            <td>{{ offer.offer_expiry|date:"M j, Y"|default:"-" }}</td>
+          </tr>
+          {% endfor %}
+        </table>
+      {% else %}
+        <p class="help-text">No offers yet.</p>
+      {% endif %}
+    </div>
+
+  </div>
+</div>
+{% endblock %}

--- a/templates/pipeline/pipeline_detail.html
+++ b/templates/pipeline/pipeline_detail.html
@@ -111,19 +111,22 @@
     </div>
     {% endif %}
 
-    {# Action buttons #}
-    <div class="pipeline-action-bar">
-      {% if prop.status == 'ACTIVE' and prop.stage != 'STABILIZED' %}
-        <span class="btn btn-primary btn-placeholder">Advance Stage</span>
-      {% endif %}
-      {% if prop.status == 'ACTIVE' %}
-      <span class="btn btn-danger" onclick="document.getElementById('kill-modal').style.display='block'">Kill</span>
-      <span class="btn btn-outline btn-placeholder">Hold</span>
-      {% endif %}
-      {% if prop.status == 'KILLED' or prop.status == 'ON_HOLD' %}
-      <span class="btn btn-warning btn-placeholder">Reactivate</span>
-      {% endif %}
-    </div>
+     {# Action buttons #}
+     <div class="pipeline-action-bar">
+       {% if prop.status == 'ACTIVE' and prop.stage != 'STABILIZED' %}
+         <a href="{% url 'pipeline_offer_create' prop.pk %}" class="btn btn-primary">Add Offer</a>
+         <a href="{% url 'pipeline_dd_checklist' prop.pk %}" class="btn btn-outline">Due Diligence</a>
+         <a href="{% url 'pipeline_renovation' prop.pk %}" class="btn btn-outline">Renovation</a>
+         <span class="btn btn-primary btn-placeholder">Advance Stage</span>
+       {% endif %}
+       {% if prop.status == 'ACTIVE' %}
+       <span class="btn btn-danger" onclick="document.getElementById('kill-modal').style.display='block'">Kill</span>
+       <span class="btn btn-outline btn-placeholder">Hold</span>
+       {% endif %}
+       {% if prop.status == 'KILLED' or prop.status == 'ON_HOLD' %}
+       <span class="btn btn-warning btn-placeholder">Reactivate</span>
+       {% endif %}
+     </div>
 
   </div>{# end grid #}
 

--- a/templates/pipeline/renovation_form.html
+++ b/templates/pipeline/renovation_form.html
@@ -1,0 +1,107 @@
+{% extends "base.html" %}
+{% load humanize %}
+
+{% block title %}Renovation — {{ prop.address|truncatechars:30 }} — prei{% endblock %}
+
+{% block content %}
+<div class="pipeline-page">
+
+  <div class="pipeline-detail-header">
+    <div>
+      <a href="{% url 'pipeline_detail' prop.pk %}" class="back-link">&larr; Back to Property</a>
+      <h1>Renovation Record</h1>
+      <p class="help-text">{{ prop.address }}</p>
+    </div>
+  </div>
+
+  <form method="post">
+    {% csrf_token %}
+
+    <div class="pipeline-detail-body">
+
+      {# Budget & Timeline #}
+      <div class="pipeline-detail-section">
+        <h2>Budget &amp; Timeline</h2>
+        <div class="form-row">
+          <div class="form-field-group">
+            <label class="field-label">Estimated Budget ($)</label>
+            <input type="number" name="estimated_budget" step="0.01" min="0"
+                   value="{{ renovation.estimated_budget|default:'' }}" class="field-input input-lg">
+          </div>
+          <div class="form-field-group">
+            <label class="field-label">Actual Cost ($)</label>
+            <input type="number" name="actual_cost" step="0.01" min="0"
+                   value="{{ renovation.actual_cost|default:'' }}" class="field-input input-lg">
+          </div>
+        </div>
+        <div class="form-row mt-2">
+          <div class="form-field-group">
+            <label class="field-label">Start Date</label>
+            <input type="date" name="start_date"
+                   value="{{ renovation.start_date|date:'Y-m-d'|default:'' }}" class="field-input input-md">
+          </div>
+          <div class="form-field-group">
+            <label class="field-label">Completion Date</label>
+            <input type="date" name="completion_date"
+                   value="{{ renovation.completion_date|date:'Y-m-d'|default:'' }}" class="field-input input-md">
+          </div>
+        </div>
+      </div>
+
+      {# Contractor & Scope #}
+      <div class="pipeline-detail-section">
+        <h2>Contractor &amp; Scope</h2>
+        <div class="form-field-group">
+          <label class="field-label">Contractor</label>
+          <input type="text" name="contractor" value="{{ renovation.contractor }}"
+                 class="field-input input-full">
+        </div>
+        <div class="form-field-group mt-2">
+          <label class="field-label">Scope of Work</label>
+          <textarea name="scope_of_work" rows="4" class="field-input input-full">{{ renovation.scope_of_work }}</textarea>
+        </div>
+      </div>
+
+      {# Status #}
+      <div class="pipeline-detail-section">
+        <h2>Status</h2>
+        <div class="form-row">
+          <label class="checkbox-label">
+            <input type="radio" name="status" value="not_started" {% if renovation.status == 'not_started' %}checked{% endif %}>
+            Not Started
+          </label>
+          <label class="checkbox-label">
+            <input type="radio" name="status" value="in_progress" {% if renovation.status == 'in_progress' %}checked{% endif %}>
+            In Progress
+          </label>
+          <label class="checkbox-label">
+            <input type="radio" name="status" value="complete" {% if renovation.status == 'complete' %}checked{% endif %}>
+            Complete
+          </label>
+        </div>
+      </div>
+
+      {# Notes #}
+      <div class="pipeline-detail-section">
+        <h2>Notes</h2>
+        <textarea name="notes" rows="3" class="field-input input-full">{{ renovation.notes }}</textarea>
+      </div>
+
+      {# Save + leasing link #}
+      <div class="pipeline-detail-section full-width">
+        <div class="pipeline-action-bar">
+          <button type="submit" class="btn btn-primary">Save Renovation Record</button>
+          {% if renovation.status == 'complete' %}
+            {# djlint:off D018 #}
+            <a href="/leasing/add/?property_id={{ prop.pk }}" class="btn btn-warning">
+              + Add to Leasing Pipeline &rarr;
+            </a>
+            {# djlint:on #}
+          {% endif %}
+        </div>
+      </div>
+
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/tests/test_pipeline_forms.py
+++ b/tests/test_pipeline_forms.py
@@ -1,0 +1,193 @@
+"""Tests for PIPE-8: Offer, DD, and Renovation forms + views.
+
+Tests cover:
+- Offer creation and listing
+- DD checklist save and no-go kill
+- Renovation record save
+- 404 for non-owner access
+- Login required
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+from django.utils import timezone
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="pipe8",
+        email="pipe8@test.com",
+        password="testpass123",
+    )
+
+
+@pytest.fixture
+def client(db, user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+@pytest.fixture
+def pipeline_property(db, user):
+    from core.models import PipelineProperty
+
+    pp = PipelineProperty.objects.create(
+        user=user,
+        source_type="manual",
+        source_id="pipe8-test",
+        address="123 Pipeline Ave, Austin TX 78701",
+        address_hash="pipe8-hash",
+        stage=PipelineProperty.Stage.DISCOVERED,
+        status=PipelineProperty.Status.ACTIVE,
+        price=Decimal("250000"),
+        beds=3,
+        discovered_at=timezone.now(),
+    )
+    return pp
+
+
+class TestOfferCreate:
+    def test_requires_login(self, db, pipeline_property):
+        c = Client()
+        url = reverse("pipeline_offer_create", kwargs={"pk": pipeline_property.pk})
+        resp = c.get(url)
+        assert resp.status_code == 302
+        assert "/login/" in resp.url
+
+    def test_404_for_other_user(self, db, pipeline_property):
+        other = User.objects.create_user(
+            username="other", email="other@test.com", password="pass"
+        )
+        c = Client()
+        c.force_login(other)
+        url = reverse("pipeline_offer_create", kwargs={"pk": pipeline_property.pk})
+        resp = c.get(url)
+        assert resp.status_code == 404
+
+    def test_get_shows_form(self, client, pipeline_property):
+        url = reverse("pipeline_offer_create", kwargs={"pk": pipeline_property.pk})
+        resp = client.get(url)
+        assert resp.status_code == 200
+        assert b"Offer" in resp.content
+
+    def test_post_creates_offer(self, client, pipeline_property):
+        from core.models import OfferRecord
+
+        url = reverse("pipeline_offer_create", kwargs={"pk": pipeline_property.pk})
+        resp = client.post(
+            url,
+            {
+                "offer_price": "300000",
+                "offer_date": "2026-07-10",
+                "contingencies": ["inspection", "financing"],
+                "notes": "Initial offer",
+            },
+        )
+        assert resp.status_code == 302
+        assert (
+            OfferRecord.objects.filter(pipeline_property=pipeline_property).count() == 1
+        )
+
+    def test_list_existing_offers(self, client, pipeline_property):
+        from core.models import OfferRecord
+
+        OfferRecord.objects.create(
+            pipeline_property=pipeline_property,
+            offer_price=Decimal("300000"),
+            offer_date="2026-07-10",
+        )
+        url = reverse("pipeline_offer_create", kwargs={"pk": pipeline_property.pk})
+        resp = client.get(url)
+        assert resp.status_code == 200
+        assert b"300,000" in resp.content or b"300000" in resp.content
+
+
+class TestDDChecklist:
+    def test_get_shows_form(self, client, pipeline_property):
+        url = reverse("pipeline_dd_checklist", kwargs={"pk": pipeline_property.pk})
+        resp = client.get(url)
+        assert resp.status_code == 200
+        assert b"Go / No-Go" in resp.content
+
+    def test_post_saves_checklist(self, client, pipeline_property):
+        from core.models import DueDiligenceChecklist
+
+        url = reverse("pipeline_dd_checklist", kwargs={"pk": pipeline_property.pk})
+        resp = client.post(
+            url,
+            {
+                "inspection_scheduled": "1",
+                "title_search_ordered": "1",
+                "go_no_go": "pending",
+            },
+        )
+        assert resp.status_code == 302
+        dd = DueDiligenceChecklist.objects.get(pipeline_property=pipeline_property)
+        assert dd.inspection_scheduled is True
+        assert dd.title_search_ordered is True
+
+    def test_no_go_kills_property(self, client, pipeline_property):
+
+        url = reverse("pipeline_dd_checklist", kwargs={"pk": pipeline_property.pk})
+        resp = client.post(
+            url,
+            {
+                "go_no_go": "no_go",
+                "no_go_reason": "Failed inspection — foundation issues",
+            },
+        )
+        assert resp.status_code == 302
+        pipeline_property.refresh_from_db()
+        assert pipeline_property.status == "KILLED"
+        assert "foundation" in pipeline_property.kill_reason
+
+
+class TestRenovation:
+    def test_get_shows_form(self, client, pipeline_property):
+        url = reverse("pipeline_renovation", kwargs={"pk": pipeline_property.pk})
+        resp = client.get(url)
+        assert resp.status_code == 200
+        assert b"Renovation" in resp.content
+
+    def test_post_saves_renovation(self, client, pipeline_property):
+        from core.models import RenovationRecord
+
+        url = reverse("pipeline_renovation", kwargs={"pk": pipeline_property.pk})
+        resp = client.post(
+            url,
+            {
+                "estimated_budget": "35000",
+                "contractor": "ABC Remodeling",
+                "scope_of_work": "Kitchen and bathroom renovation",
+                "status": "in_progress",
+                "start_date": "2026-08-01",
+            },
+        )
+        assert resp.status_code == 302
+        ren = RenovationRecord.objects.get(pipeline_property=pipeline_property)
+        assert ren.estimated_budget == Decimal("35000")
+        assert ren.contractor == "ABC Remodeling"
+        assert ren.status == "in_progress"
+
+    def test_complete_shows_leasing_link(self, client, pipeline_property):
+        from core.models import RenovationRecord
+
+        RenovationRecord.objects.create(
+            pipeline_property=pipeline_property,
+            estimated_budget=Decimal("35000"),
+            status="complete",
+        )
+        url = reverse("pipeline_renovation", kwargs={"pk": pipeline_property.pk})
+        resp = client.get(url)
+        assert resp.status_code == 200
+        assert b"Leasing" in resp.content


### PR DESCRIPTION
## Problem

Pipeline has no forms or views to create OfferRecord, DueDiligenceChecklist, or RenovationRecord for PipelineProperty items.

## Solution

### 3 new views (all login-required, 404 for non-owner):

**pipeline_offer_create** at /pipeline/\<pk\>/offer/
- GET: shows form + lists existing offers
- POST: creates OfferRecord with offer_price, offer_date, offer_expiry, contingencies (checkboxes), notes
- Multiple offers allowed per property

**pipeline_dd_checklist** at /pipeline/\<pk\>/dd/
- Section-by-section layout: Inspection, Title, Appraisal, Insurance, Contractor
- Go/No-Go decision with prominent radio buttons
- When no_go + no_go_reason set: calls kill_property() from pipeline service

**pipeline_renovation** at /pipeline/\<pk\>/renovation/
- Budget (estimated + actual), dates, contractor, scope of work, status
- When status=complete: shows 'Add to Leasing Pipeline →' button

### Template Changes
- All templates use CSS classes from pipeline.css (no inline layout styles)
- pipeline_detail.html wired with action buttons: Add Offer, Due Diligence, Renovation

## Validation
- `python -m pytest tests/test_pipeline_forms.py`: **11 passed**
- `python -m pytest tests/test_pipeline_forms.py tests/test_screening.py tests/test_pipeline_service.py -q`: **78 passed**
- `python manage.py check`: No issues
- Pre-commit: ruff, mypy, djlint, commitizen, bandit — all pass

## Risks
- Low. Depends on PIPE-7 models (OfferRecord, DueDiligenceChecklist, RenovationRecord) which are merged.
- Leasing pipeline link uses hardcoded URL (/leasing/add/) — update when leasing views are built.

Closes: PIPE-8 (Build offer, DD, and renovation forms + views)