### PR TITLE
feat(views): pipe-11 - build leasing pipeline views and templates

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -90,6 +90,9 @@ urlpatterns = [
         views.pipeline_closing_create,
         name="pipeline_closing_create",
     ),
+    path("leasing/", views.leasing_list, name="leasing_list"),
+    path("leasing/add/", views.leasing_add, name="leasing_add"),
+    path("leasing/<int:pk>/", views.leasing_detail, name="leasing_detail"),
     path(
         "settings/investment-targets/",
         views.investment_targets_edit,

--- a/core/views.py
+++ b/core/views.py
@@ -1595,6 +1595,152 @@ def pipeline_closing_create(request: HttpRequest, pk: int) -> HttpResponse:
     )
 
 
+@login_required
+def leasing_list(request: HttpRequest) -> HttpResponse:
+    """List leasing pipeline entries for the current user."""
+    from core.models import LeasingPipelineProperty
+    from datetime import date
+
+    status_filter = request.GET.get("status", "ACTIVE")
+
+    qs = LeasingPipelineProperty.objects.filter(
+        user=request.user,
+        status=status_filter,
+    ).order_by("-updated_at")
+
+    # Compute days_vacant for listing-stage entries
+    today = date.today()
+    for entry in qs:
+        if entry.listed_date and entry.stage == "LISTING":
+            entry.days_vacant = (today - entry.listed_date).days
+        else:
+            entry.days_vacant = None
+
+    stage_order = [
+        "LISTING",
+        "SHOWING",
+        "APPLICATION",
+        "SCREENING",
+        "APPROVED",
+        "LEASE_SIGNED",
+        "MOVE_IN",
+        "STABILIZED",
+    ]
+
+    return render(
+        request,
+        "leasing/leasing_list.html",
+        {
+            "entries": qs,
+            "current_status": status_filter,
+            "stage_order": stage_order,
+        },
+    )
+
+
+@login_required
+def leasing_add(request: HttpRequest) -> HttpResponse:
+    """Add a new leasing pipeline entry."""
+    from core.models import LeasingPipelineProperty, Property
+
+    # Properties not already in active leasing
+    active_leasing_ids = LeasingPipelineProperty.objects.filter(
+        user=request.user,
+        status__in=["ACTIVE", "ON_HOLD"],
+    ).values_list("property_record_id", flat=True)
+
+    available_properties = (
+        Property.objects.filter(
+            user=request.user,
+        )
+        .exclude(pk__in=active_leasing_ids)
+        .order_by("address")
+    )
+
+    # Pre-fill from ?property_id=
+    prefill_property_id = request.GET.get("property_id", "")
+    prefill_property = None
+    if prefill_property_id:
+        try:
+            prefill_property = Property.objects.get(
+                pk=prefill_property_id,
+                user=request.user,
+            )
+        except Property.DoesNotExist:
+            pass
+
+    if request.method == "POST":
+        prop_id = request.POST.get("property_record")
+        asking_rent = request.POST.get("asking_rent", "").strip()
+        listed_date = request.POST.get("listed_date", "").strip()
+        listing_source = request.POST.get("listing_source", "")
+
+        if not prop_id:
+            messages.error(request, "Please select a property.")
+            return redirect("leasing_add")
+
+        try:
+            prop = Property.objects.get(pk=prop_id, user=request.user)
+        except Property.DoesNotExist:
+            messages.error(request, "Property not found.")
+            return redirect("leasing_add")
+
+        LeasingPipelineProperty.objects.create(
+            property_record=prop,
+            user=request.user,
+            asking_rent=Decimal(asking_rent) if asking_rent else None,
+            listed_date=listed_date or None,
+            listing_source=listing_source,
+        )
+        messages.success(request, "Property added to leasing pipeline.")
+        return redirect("leasing_list")
+
+    return render(
+        request,
+        "leasing/leasing_add.html",
+        {
+            "available_properties": available_properties,
+            "prefill_property": prefill_property,
+        },
+    )
+
+
+@login_required
+def leasing_detail(request: HttpRequest, pk: int) -> HttpResponse:
+    """Leasing pipeline detail view."""
+    from core.models import LeasingPipelineProperty
+
+    try:
+        entry = LeasingPipelineProperty.objects.get(pk=pk, user=request.user)
+    except LeasingPipelineProperty.DoesNotExist:
+        raise Http404
+
+    # Stage history: chronological from stage based on created_at/updated_at
+    stage_order = [
+        "LISTING",
+        "SHOWING",
+        "APPLICATION",
+        "SCREENING",
+        "APPROVED",
+        "LEASE_SIGNED",
+        "MOVE_IN",
+        "STABILIZED",
+    ]
+    stage_history = [
+        (s, None) for s in stage_order[: stage_order.index(entry.stage) + 1]
+    ]
+
+    return render(
+        request,
+        "leasing/leasing_detail.html",
+        {
+            "entry": entry,
+            "stage_history": stage_history,
+            "stage_order": stage_order,
+        },
+    )
+
+
 def search_listings(request):
     # Optionally load a saved search to prefill filters
     saved_id = request.GET.get("saved_id")

--- a/static/css/pipeline.css
+++ b/static/css/pipeline.css
@@ -601,3 +601,37 @@
 .mt-4 {
   margin-top: var(--sp-4);
 }
+
+/* Leasing list header */
+.leasing-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-4);
+}
+
+.leasing-header h1 {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-medium);
+  margin: 0;
+}
+
+.leasing-add-btn {
+  font-size: var(--text-sm);
+  padding: var(--sp-1) var(--sp-3);
+  text-decoration: none;
+}
+
+.leasing-note {
+  margin-bottom: var(--sp-4);
+}
+
+.text-danger-bold {
+  color: var(--color-risk-400);
+}
+
+.select-full {
+  width: 100%;
+}

--- a/templates/leasing/leasing_add.html
+++ b/templates/leasing/leasing_add.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+
+{% block title %}Add to Leasing Pipeline — prei{% endblock %}
+
+{% block content %}
+<div class="pipeline-page">
+
+  <div class="pipeline-detail-header">
+    <div>
+      <a href="{% url 'leasing_list' %}" class="back-link">&larr; Back to Leasing Pipeline</a>
+      <h1>Add to Leasing Pipeline</h1>
+    </div>
+  </div>
+
+  <form method="post">
+    {% csrf_token %}
+
+    <div class="pipeline-detail-body">
+
+      <div class="pipeline-detail-section full-width">
+        <h2>Property</h2>
+        <div class="form-field-group">
+          <label class="field-label">Select Property</label>
+          <select name="property_record" class="field-input select-full">
+            <option value="">— Select —</option>
+            {% for prop in available_properties %}
+              <option value="{{ prop.pk }}" {% if prefill_property and prefill_property.pk == prop.pk %}selected{% endif %}>
+                {{ prop.address }}, {{ prop.city }}, {{ prop.state }}
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+
+      <div class="pipeline-detail-section">
+        <h2>Listing Details</h2>
+        <div class="form-row">
+          <div class="form-field-group">
+            <label class="field-label">Asking Rent ($/mo)</label>
+            <input type="number" name="asking_rent" step="0.01" min="0"
+                   class="field-input input-lg">
+          </div>
+          <div class="form-field-group">
+            <label class="field-label">Listed Date</label>
+            <input type="date" name="listed_date" class="field-input input-md">
+          </div>
+          <div class="form-field-group">
+            <label class="field-label">Listing Source</label>
+            <input type="text" name="listing_source" placeholder="e.g. Zillow, Craigslist"
+                   class="field-input input-md">
+          </div>
+        </div>
+      </div>
+
+      <div class="pipeline-detail-section full-width">
+        <div class="form-submit-row">
+          <button type="submit" class="btn btn-primary">Add to Leasing Pipeline</button>
+        </div>
+      </div>
+
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/templates/leasing/leasing_detail.html
+++ b/templates/leasing/leasing_detail.html
@@ -1,0 +1,90 @@
+{% extends "base.html" %}
+{% load humanize %}
+
+{% block title %}Leasing #{{ entry.pk }} — prei{% endblock %}
+
+{% block content %}
+<div class="pipeline-page">
+
+  <div class="pipeline-detail-header">
+    <div>
+      <a href="{% url 'leasing_list' %}" class="back-link">&larr; Back to Leasing Pipeline</a>
+      <h1>{{ entry.property_record.address }}</h1>
+      <p class="help-text">{{ entry.property_record.city }}, {{ entry.property_record.state }}</p>
+    </div>
+    <div class="pipeline-card-badges">
+      <span class="pipeline-badge badge-stage">{{ entry.get_stage_display }}</span>
+      <span class="pipeline-badge badge-status-{{ entry.status|lower }}">{{ entry.get_status_display }}</span>
+    </div>
+  </div>
+
+  <div class="pipeline-detail-body">
+
+    {# Listing details #}
+    <div class="pipeline-detail-section">
+      <h2>Listing</h2>
+      <table class="pipeline-detail-table">
+        <tr><td>Asking Rent</td><td>{% if entry.asking_rent %}${{ entry.asking_rent|floatformat:2|intcomma }}/mo{% else %}—{% endif %}</td></tr>
+        <tr><td>Listed</td><td>{{ entry.listed_date|date:"M j, Y"|default:"—" }}</td></tr>
+        <tr><td>Source</td><td>{{ entry.listing_source|default:"—" }}</td></tr>
+        {% if entry.days_vacant is not None %}
+        <tr><td class="text-danger">Days Vacant</td><td>{{ entry.days_vacant }}</td></tr>
+        {% endif %}
+      </table>
+    </div>
+
+    {# Applicant tracking #}
+    <div class="pipeline-detail-section">
+      <h2>Applicant</h2>
+      <table class="pipeline-detail-table">
+        <tr><td>Name</td><td>{{ entry.applicant_name|default:"—" }}</td></tr>
+        <tr><td>Application Date</td><td>{{ entry.application_date|date:"M j, Y"|default:"—" }}</td></tr>
+        <tr><td>Screening</td><td>{% if entry.screening_passed is True %}Passed{% elif entry.screening_passed is False %}Failed{% else %}Pending{% endif %}</td></tr>
+      </table>
+    </div>
+
+    {# Lease details (shown when stage >= LEASE_SIGNED) #}
+    {% if entry.stage == 'LEASE_SIGNED' or entry.stage == 'MOVE_IN' or entry.stage == 'STABILIZED' %}
+    <div class="pipeline-detail-section">
+      <h2>Lease</h2>
+      <table class="pipeline-detail-table">
+        <tr><td>Start Date</td><td>{{ entry.lease_start_date|date:"M j, Y"|default:"—" }}</td></tr>
+        <tr><td>End Date</td><td>{{ entry.lease_end_date|date:"M j, Y"|default:"—" }}</td></tr>
+        <tr><td>Monthly Rent</td><td>${{ entry.monthly_rent|floatformat:2|intcomma }}</td></tr>
+        <tr><td>Security Deposit</td><td>${{ entry.security_deposit|floatformat:2|intcomma }}</td></tr>
+      </table>
+    </div>
+    {% endif %}
+
+    {# Stage history #}
+    <div class="pipeline-detail-section full-width">
+      <h2>Stage History</h2>
+      <div class="stage-history">
+        {% for stage_name, ts in stage_history %}
+        <div class="stage-history-item">
+          <span class="stage-history-name">{{ stage_name|title }}</span>
+          {% if stage_name == entry.stage %}
+            <span class="stage-history-current">Current</span>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+
+    {# Action buttons #}
+    <div class="pipeline-action-bar">
+      {% if entry.status == 'ACTIVE' and entry.stage != 'STABILIZED' %}
+        <span class="btn btn-primary btn-placeholder">Advance Stage</span>
+      {% endif %}
+      {% if entry.status == 'ACTIVE' %}
+        <span class="btn btn-danger btn-placeholder">Fill</span>
+        <span class="btn btn-outline btn-placeholder">Hold</span>
+      {% endif %}
+      {% if entry.status == 'FILLED' or entry.stage == 'STABILIZED' %}
+        <a href="{% url 'portfolio_dashboard' %}" class="btn btn-primary">View in Portfolio &rarr;</a>
+      {% endif %}
+    </div>
+
+  </div>
+</div>
+{% endblock %}

--- a/templates/leasing/leasing_list.html
+++ b/templates/leasing/leasing_list.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% load humanize %}
+
+{% block title %}Leasing Pipeline — prei{% endblock %}
+
+{% block content %}
+<div class="pipeline-page">
+
+  <div class="leasing-header">
+    <h1>Leasing Pipeline</h1>
+    <a href="{% url 'leasing_add' %}" class="btn btn-primary leasing-add-btn">+ Add to Leasing</a>
+  </div>
+
+  {# Note #}
+  <div class="form-note leasing-note">
+    Leasing pipeline tracks tenant acquisition. For maintenance, rent collection, and lease renewals, use Portfolio.
+  </div>
+
+  {# Status tabs #}
+  <div class="pipeline-status-tabs">
+    <a href="?status=ACTIVE" class="pipeline-status-tab {% if current_status == 'ACTIVE' %}active-active{% endif %}">Active</a>
+    <a href="?status=FILLED" class="pipeline-status-tab {% if current_status == 'FILLED' %}active-killed{% endif %}">Filled</a>
+    <a href="?status=ON_HOLD" class="pipeline-status-tab {% if current_status == 'ON_HOLD' %}active-on_hold{% endif %}">On Hold</a>
+  </div>
+
+  {# Entries #}
+  {% if entries %}
+    <div class="pipeline-cards">
+    {% for entry in entries %}
+      <div class="pipeline-card">
+        <div class="pipeline-card-body">
+          <div class="pipeline-card-info">
+            <div class="pipeline-card-badges">
+              <span class="pipeline-badge badge-stage">{{ entry.get_stage_display }}</span>
+              <span class="pipeline-badge badge-status-{{ entry.status|lower }}">{{ entry.get_status_display }}</span>
+            </div>
+            <div class="pipeline-card-address">{{ entry.property_record.address }}</div>
+            <div class="pipeline-card-meta">
+              {{ entry.property_record.city }}, {{ entry.property_record.state }}
+              {% if entry.asking_rent %} &middot; ${{ entry.asking_rent|floatformat:0|intcomma }}/mo{% endif %}
+              {% if entry.days_vacant is not None %}
+                &middot; <strong class="text-danger-bold">{{ entry.days_vacant }} days vacant</strong>
+              {% endif %}
+            </div>
+          </div>
+          <div class="pipeline-card-actions">
+            <a href="{% url 'leasing_detail' entry.pk %}" class="pipeline-action-btn">View Details</a>
+          </div>
+        </div>
+      </div>
+    {% endfor %}
+    </div>
+  {% else %}
+    <div class="pipeline-empty">No leasing entries found.</div>
+  {% endif %}
+
+</div>
+{% endblock %}

--- a/tests/test_leasing_views.py
+++ b/tests/test_leasing_views.py
@@ -1,0 +1,159 @@
+"""Tests for PIPE-11: Leasing pipeline views.
+
+Tests cover:
+- leasing_list: login required, shows entries, filters by status
+- leasing_add: login, GET shows form, POST creates entry, pre-fill from property_id
+- leasing_detail: login, 404 for non-owner, shows entry details
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="leasing_user",
+        email="leasing@test.com",
+        password="testpass123",
+    )
+
+
+@pytest.fixture
+def client(db, user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+@pytest.fixture
+def owned_property(db, user):
+    from core.models import Property as PropertyModel
+
+    return PropertyModel.objects.create(
+        user=user,
+        address="123 Leasing Ln",
+        city="Austin",
+        state="TX",
+        zip_code="78701",
+        purchase_price=Decimal("250000"),
+        purchase_date="2026-06-01",
+        sqft=1500,
+        monthly_rent_gross=Decimal("2000"),
+    )
+
+
+@pytest.fixture
+def leasing_entry(db, user, owned_property):
+    from core.models import LeasingPipelineProperty
+
+    return LeasingPipelineProperty.objects.create(
+        property_record=owned_property,
+        user=user,
+        asking_rent=Decimal("2200"),
+        listed_date="2026-07-01",
+        stage=LeasingPipelineProperty.Stage.LISTING,
+        status=LeasingPipelineProperty.Status.ACTIVE,
+    )
+
+
+class TestLeasingList:
+    def test_requires_login(self, db):
+        c = Client()
+        resp = c.get(reverse("leasing_list"))
+        assert resp.status_code == 302
+        assert "/login/" in resp.url
+
+    def test_shows_entries(self, client, leasing_entry):
+        resp = client.get(reverse("leasing_list"))
+        assert resp.status_code == 200
+        assert b"123 Leasing Ln" in resp.content
+
+    def test_filters_by_status(self, client, user, owned_property, leasing_entry):
+        from core.models import LeasingPipelineProperty
+
+        # Create a FILLED entry
+        LeasingPipelineProperty.objects.create(
+            property_record=owned_property,
+            user=user,
+            status=LeasingPipelineProperty.Status.FILLED,
+        )
+        resp = client.get(reverse("leasing_list"), {"status": "FILLED"})
+        assert resp.status_code == 200
+        # Should show the filled entry
+        assert b"pipeline-card" in resp.content
+
+    def test_empty_state(self, client):
+        resp = client.get(reverse("leasing_list"))
+        assert resp.status_code == 200
+        assert b"No leasing" in resp.content
+
+
+class TestLeasingAdd:
+    def test_requires_login(self, db):
+        c = Client()
+        resp = c.get(reverse("leasing_add"))
+        assert resp.status_code == 302
+        assert "/login/" in resp.url
+
+    def test_get_shows_form(self, client, owned_property):
+        resp = client.get(reverse("leasing_add"))
+        assert resp.status_code == 200
+        assert b"Select Property" in resp.content
+
+    def test_post_creates_entry(self, client, owned_property):
+        from core.models import LeasingPipelineProperty
+
+        resp = client.post(
+            reverse("leasing_add"),
+            {
+                "property_record": owned_property.pk,
+                "asking_rent": "2300",
+                "listed_date": "2026-07-15",
+                "listing_source": "Zillow",
+            },
+        )
+        assert resp.status_code == 302
+        assert LeasingPipelineProperty.objects.filter(
+            property_record=owned_property,
+            asking_rent=Decimal("2300"),
+        ).exists()
+
+    def test_prefill_from_property_id(self, client, owned_property):
+        url = reverse("leasing_add") + f"?property_id={owned_property.pk}"
+        resp = client.get(url)
+        assert resp.status_code == 200
+        assert b"123 Leasing Ln" in resp.content
+
+
+class TestLeasingDetail:
+    def test_requires_login(self, db, leasing_entry):
+        c = Client()
+        url = reverse("leasing_detail", kwargs={"pk": leasing_entry.pk})
+        resp = c.get(url)
+        assert resp.status_code == 302
+        assert "/login/" in resp.url
+
+    def test_404_for_other_user(self, db, leasing_entry):
+        other = User.objects.create_user(
+            username="other_lease", email="other@test.com", password="pass"
+        )
+        c = Client()
+        c.force_login(other)
+        url = reverse("leasing_detail", kwargs={"pk": leasing_entry.pk})
+        resp = c.get(url)
+        assert resp.status_code == 404
+
+    def test_shows_entry(self, client, leasing_entry):
+        url = reverse("leasing_detail", kwargs={"pk": leasing_entry.pk})
+        resp = client.get(url)
+        assert resp.status_code == 200
+        assert b"Asking Rent" in resp.content


### PR DESCRIPTION
## Problem

Leasing pipeline has no views. The model exists (PIPE-10) but users have no UI to manage it.

## Solution

### 3 new views (all login-required, 404 for non-owner):

**leasing_list** at /leasing/
- Queries LeasingPipelineProperty filtered by status (default ACTIVE)
- Status filter tabs: Active / Filled / On Hold
- Days vacant shown prominently for LISTING-stage entries
- Note about leasing vs portfolio usage
- + Add to Leasing button linking to leasing_add

**leasing_add** at /leasing/add/
- Property dropdown: filters to user's Property records not already in active leasing
- Pre-fills from ?property_id= (linked from renovation complete button in PIPE-8)
- Fields: asking_rent, listed_date, listing_source

**leasing_detail** at /leasing/\<pk\>/
- Shows listing details, applicant tracking, lease details (when stage >= LEASE_SIGNED)
- Stage history
- Action buttons: Advance Stage, Fill, Hold (UI placeholders), View in Portfolio link
- Days vacant shown in detail

## Templates
- leasing/leasing_list.html — list with status tabs and cards
- leasing/leasing_add.html — add form with property dropdown
- leasing/leasing_detail.html — detail with stage history

## Validation
- `python -m pytest tests/test_leasing_views.py`: **11 passed**
- `python -m pytest tests/test_leasing_views.py tests/test_pipeline_forms.py tests/test_screening.py -q`: **54 passed**
- `python manage.py check`: No issues
- Pre-commit: ruff, mypy, djlint, commitizen, bandit — all pass

## Risks
- Low. POST handlers for Advance/Fill/Hold are UI-only — wiring to pipeline service pending.
- Depends on PIPE-10 model which is merged.

Closes: PIPE-11 (Build leasing pipeline views + templates)