### PR TITLE
feat(discovery): add HUD and USDA property views with Add to Pipeline

### DIFF
--- a/core/services/pipeline.py
+++ b/core/services/pipeline.py
@@ -328,6 +328,132 @@ def create_from_foreclosure(
     return pp, True
 
 
+def create_from_hud(
+    hud_property: Any,
+    user: Any,
+) -> Tuple[Any, bool]:
+    """Create a PipelineProperty from a HudProperty and run screening.
+
+    Same pattern as create_from_vrm. HudProperty has no rent data,
+    so yield/PTR criteria are skipped during screening.
+
+    Args:
+        hud_property: HudProperty instance.
+        user: Django User who owns this pipeline entry.
+
+    Returns:
+        Tuple of (PipelineProperty, created).
+    """
+    from core.models import HudProperty, PipelineProperty, ScreeningCriteria
+    from core.services.screening import screen_property
+
+    if not isinstance(hud_property, HudProperty):
+        raise TypeError("Expected HudProperty instance")
+
+    criteria, _ = ScreeningCriteria.objects.get_or_create(user=user)
+
+    price = hud_property.asking_price or hud_property.list_price
+
+    pp, created = PipelineProperty.objects.get_or_create(
+        user=user,
+        source_type=PipelineProperty.SourceType.HUD,
+        source_id=str(hud_property.hud_case_number),
+        defaults={
+            "address": hud_property.address or "",
+            "address_hash": "",
+            "stage": PipelineProperty.Stage.DISCOVERED,
+            "status": PipelineProperty.Status.ACTIVE,
+            "price": price,
+            "estimated_rent": None,
+            "beds": hud_property.bedrooms,
+            "year_built": None,
+            "discovered_at": timezone.now(),
+        },
+    )
+
+    if not created:
+        return pp, False
+
+    # Run screening immediately
+    result = screen_property(pp, criteria, source_record=hud_property)
+
+    pp.screening_passed = result.passed
+    pp.screening_at = timezone.now()
+    pp.stage = PipelineProperty.Stage.SCREENING
+    pp.save(
+        update_fields=[
+            "screening_passed",
+            "screening_at",
+            "stage",
+            "updated_at",
+        ]
+    )
+
+    return pp, True
+
+
+def create_from_usda(
+    usda_property: Any,
+    user: Any,
+) -> Tuple[Any, bool]:
+    """Create a PipelineProperty from a UsdaProperty and run screening.
+
+    Same pattern as create_from_hud. UsdaProperty has no rent data,
+    so yield/PTR criteria are skipped during screening.
+
+    Args:
+        usda_property: UsdaProperty instance.
+        user: Django User who owns this pipeline entry.
+
+    Returns:
+        Tuple of (PipelineProperty, created).
+    """
+    from core.models import PipelineProperty, ScreeningCriteria, UsdaProperty
+    from core.services.screening import screen_property
+
+    if not isinstance(usda_property, UsdaProperty):
+        raise TypeError("Expected UsdaProperty instance")
+
+    criteria, _ = ScreeningCriteria.objects.get_or_create(user=user)
+
+    pp, created = PipelineProperty.objects.get_or_create(
+        user=user,
+        source_type=PipelineProperty.SourceType.USDA,
+        source_id=str(usda_property.usda_case_number),
+        defaults={
+            "address": usda_property.address or "",
+            "address_hash": "",
+            "stage": PipelineProperty.Stage.DISCOVERED,
+            "status": PipelineProperty.Status.ACTIVE,
+            "price": usda_property.list_price,
+            "estimated_rent": None,
+            "beds": usda_property.bedrooms,
+            "year_built": None,
+            "discovered_at": timezone.now(),
+        },
+    )
+
+    if not created:
+        return pp, False
+
+    # Run screening immediately
+    result = screen_property(pp, criteria, source_record=usda_property)
+
+    pp.screening_passed = result.passed
+    pp.screening_at = timezone.now()
+    pp.stage = PipelineProperty.Stage.SCREENING
+    pp.save(
+        update_fields=[
+            "screening_passed",
+            "screening_at",
+            "stage",
+            "updated_at",
+        ]
+    )
+
+    return pp, True
+
+
 # ── Conversion to Property record ──────────────────────────────────────────────
 
 

--- a/core/tests/test_discovery_views.py
+++ b/core/tests/test_discovery_views.py
@@ -1,0 +1,155 @@
+"""Acceptance tests for HUD/USDA property list/detail views and Add to Pipeline."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+from core.models import (
+    HudProperty,
+    PipelineProperty,
+    ScreeningCriteria,
+    UsdaProperty,
+)
+
+UserModel = get_user_model()
+
+
+@pytest.fixture
+def user() -> UserModel:  # type: ignore[valid-type]
+    return UserModel.objects.create_user(
+        username="discovery_user",
+        password="testpass",
+    )
+
+
+@pytest.fixture
+def criteria(user: UserModel) -> ScreeningCriteria:  # type: ignore[valid-type]
+    return ScreeningCriteria.objects.create(
+        user=user,
+        allowed_states=["TX"],
+        min_price=Decimal("50000"),
+        max_price=Decimal("500000"),
+    )
+
+
+@pytest.fixture
+def hud_prop() -> HudProperty:
+    return HudProperty.objects.create(
+        hud_case_number="HUD-PIPELINE-001",
+        address="111 Pipeline Dr",
+        city="Austin",
+        state="TX",
+        zip_code="78701",
+        asking_price=Decimal("150000"),
+        status=HudProperty.Status.ACTIVE,
+        scraped_at=timezone.now(),
+        last_seen_at=timezone.now(),
+    )
+
+
+@pytest.fixture
+def usda_prop() -> UsdaProperty:
+    return UsdaProperty.objects.create(
+        usda_case_number="USDA-PIPELINE-001",
+        address="222 Rural Rd",
+        city="Dallas",
+        state="TX",
+        zip_code="75201",
+        list_price=Decimal("180000"),
+        status=UsdaProperty.Status.ACTIVE,
+        scraped_at=timezone.now(),
+        last_seen_at=timezone.now(),
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# HUD list view
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.django_db
+def test_hud_list_view_returns_200(
+    client: Any,
+    user: UserModel,  # type: ignore[valid-type]
+    hud_prop: HudProperty,
+) -> None:
+    """HUD property list view returns 200 for authenticated user."""
+    client.force_login(user)
+    response = client.get(reverse("hud_property_list"))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_hud_add_to_pipeline_creates_pipeline_property(
+    client: Any,
+    user: UserModel,  # type: ignore[valid-type]
+    hud_prop: HudProperty,
+    criteria: ScreeningCriteria,
+) -> None:
+    """Add to Pipeline POST creates PipelineProperty with source_type='hud'."""
+    client.force_login(user)
+    response = client.post(
+        reverse("pipeline_add_from_source"),
+        {
+            "source_type": "hud",
+            "source_id": hud_prop.hud_case_number,
+        },
+    )
+
+    # Should redirect to pipeline detail
+    assert response.status_code == 302
+
+    assert PipelineProperty.objects.filter(
+        source_type="hud",
+        source_id=hud_prop.hud_case_number,
+        user=user,
+    ).exists()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# USDA list view
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.django_db
+def test_usda_list_view_returns_200(
+    client: Any,
+    user: UserModel,  # type: ignore[valid-type]
+    usda_prop: UsdaProperty,
+) -> None:
+    """USDA property list view returns 200 for authenticated user."""
+    client.force_login(user)
+    response = client.get(reverse("usda_property_list"))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_usda_add_to_pipeline_creates_pipeline_property(
+    client: Any,
+    user: UserModel,  # type: ignore[valid-type]
+    usda_prop: UsdaProperty,
+    criteria: ScreeningCriteria,
+) -> None:
+    """Add to Pipeline POST creates PipelineProperty with source_type='usda'."""
+    client.force_login(user)
+    response = client.post(
+        reverse("pipeline_add_from_source"),
+        {
+            "source_type": "usda",
+            "source_id": usda_prop.usda_case_number,
+        },
+    )
+
+    assert response.status_code == 302
+
+    assert PipelineProperty.objects.filter(
+        source_type="usda",
+        source_id=usda_prop.usda_case_number,
+        user=user,
+    ).exists()

--- a/core/urls.py
+++ b/core/urls.py
@@ -56,6 +56,22 @@ urlpatterns = [
     path("portfolio/", portfolio_dashboard, name="portfolio_dashboard"),
     path("portfolio/actuals/add/", portfolio_actuals_add, name="portfolio_actuals_add"),
     path("vrm-properties/", views.vrm_properties_list, name="vrm_properties_list"),
+    path("hud-properties/", views.hud_property_list, name="hud_property_list"),
+    path(
+        "hud-properties/<int:pk>/",
+        views.hud_property_detail,
+        name="hud_property_detail",
+    ),
+    path(
+        "usda-properties/",
+        views.usda_property_list,
+        name="usda_property_list",
+    ),
+    path(
+        "usda-properties/<int:pk>/",
+        views.usda_property_detail,
+        name="usda_property_detail",
+    ),
     path("growth-explorer/", views.growth_explorer, name="growth_explorer"),
     path("discovery/", views.property_discovery, name="property_discovery"),
     path("pipeline/", views.pipeline_dashboard, name="pipeline_dashboard"),

--- a/core/views.py
+++ b/core/views.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from io import BytesIO
 from collections.abc import Mapping
 from decimal import Decimal, InvalidOperation
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 from django.conf import settings
 from django.contrib import messages
@@ -39,6 +39,8 @@ from core.integrations.market.census import (
 from core.integrations.sources.fred_adapter import FREDAdapter
 
 from .models import (
+    HudProperty,
+    UsdaProperty,
     VrmProperty,
     UserInvestmentTargets,
     GrowthArea,
@@ -1252,6 +1254,50 @@ def pipeline_add_from_source(request: HttpRequest) -> HttpResponse:
 
         return redirect("pipeline_detail", pk=pp.pk)
 
+    if source_type == "hud":
+        from core.services.pipeline import create_from_hud
+
+        try:
+            hud = HudProperty.objects.get(hud_case_number=source_id)
+        except HudProperty.DoesNotExist:
+            messages.error(request, "HUD property not found")
+            return redirect(next_url)
+
+        pp, created = create_from_hud(hud, request.user)
+
+        if created:
+            verdict = "passed" if pp.screening_passed else "failed"
+            messages.success(
+                request,
+                f"HUD property added to pipeline. Screening {verdict}.",
+            )
+        else:
+            messages.info(request, "Already in your pipeline")
+
+        return redirect("pipeline_detail", pk=pp.pk)
+
+    if source_type == "usda":
+        from core.services.pipeline import create_from_usda
+
+        try:
+            usda = UsdaProperty.objects.get(usda_case_number=source_id)
+        except UsdaProperty.DoesNotExist:
+            messages.error(request, "USDA property not found")
+            return redirect(next_url)
+
+        pp, created = create_from_usda(usda, request.user)
+
+        if created:
+            verdict = "passed" if pp.screening_passed else "failed"
+            messages.success(
+                request,
+                f"USDA property added to pipeline. Screening {verdict}.",
+            )
+        else:
+            messages.info(request, "Already in your pipeline")
+
+        return redirect("pipeline_detail", pk=pp.pk)
+
     messages.error(request, f"Unknown source type: {source_type}")
     return redirect(next_url)
 
@@ -2421,3 +2467,73 @@ def property_discovery(request: HttpRequest) -> HttpResponse:
             "user_requests": user_requests,
         },
     )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# HUD Property Views
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def hud_property_list(request: HttpRequest) -> HttpResponse:
+    """List HUD properties with optional state filter."""
+    state = request.GET.get("state", "").strip().upper()
+
+    queryset = HudProperty.objects.all().order_by("-created_at")
+    if state:
+        queryset = queryset.filter(state=state)
+
+    context: dict[str, Any] = {
+        "hud_properties": queryset,
+        "selected_state": state,
+        "total_count": HudProperty.objects.count(),
+        "filtered_count": queryset.count(),
+    }
+    return render(request, "hud_properties/list.html", context)
+
+
+def hud_property_detail(
+    request: HttpRequest,
+    pk: int,
+) -> HttpResponse:
+    """Detail view for a single HUD property with Add to Pipeline button."""
+    hud_property = get_object_or_404(HudProperty, pk=pk)
+
+    context: dict[str, Any] = {
+        "hud_property": hud_property,
+    }
+    return render(request, "hud_properties/detail.html", context)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# USDA Property Views
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def usda_property_list(request: HttpRequest) -> HttpResponse:
+    """List USDA properties with optional state filter."""
+    state = request.GET.get("state", "").strip().upper()
+
+    queryset = UsdaProperty.objects.all().order_by("-created_at")
+    if state:
+        queryset = queryset.filter(state=state)
+
+    context: dict[str, Any] = {
+        "usda_properties": queryset,
+        "selected_state": state,
+        "total_count": UsdaProperty.objects.count(),
+        "filtered_count": queryset.count(),
+    }
+    return render(request, "usda_properties/list.html", context)
+
+
+def usda_property_detail(
+    request: HttpRequest,
+    pk: int,
+) -> HttpResponse:
+    """Detail view for a single USDA property with Add to Pipeline button."""
+    usda_property = get_object_or_404(UsdaProperty, pk=pk)
+
+    context: dict[str, Any] = {
+        "usda_property": usda_property,
+    }
+    return render(request, "usda_properties/detail.html", context)

--- a/docs/feature/disc-4/design.md
+++ b/docs/feature/disc-4/design.md
@@ -1,0 +1,47 @@
+# Design: DISC-4 — HUD/USDA Property List & Detail Views
+
+## Impacted Components
+
+| Component | Change |
+|---|---|
+| `core/services/pipeline.py` | Add `create_from_hud()`, `create_from_usda()` |
+| `core/views.py` | Extend `pipeline_add_from_source`; add `hud_property_list`, `hud_property_detail`, `usda_property_list`, `usda_property_detail` |
+| `core/urls.py` | Add URL patterns for HUD/USDA views |
+| `templates/hud_properties/list.html` | **New** |
+| `templates/hud_properties/detail.html` | **New** |
+| `templates/usda_properties/list.html` | **New** |
+| `templates/usda_properties/detail.html` | **New** |
+| `core/tests/test_discovery_views.py` | **New** — acceptance tests |
+
+## View Patterns
+
+### hud_property_list
+- GET: list HudProperty records with optional state filter
+- Context: `hud_properties` queryset, `states` list, `selected_state`
+- Template: `hud_properties/list.html`
+
+### hud_property_detail
+- GET by pk: single HudProperty record
+- Context: `hud_property` instance, `pipeline_add_url`
+- Template: `hud_properties/detail.html`
+- Includes "Add to Pipeline" form → POST to `pipeline_add_from_source`
+
+### usda_property_list / usda_property_detail
+- Same pattern as HUD, substituting UsdaProperty
+
+## Service Functions
+
+### create_from_hud(hud_property, user) → (PipelineProperty, created)
+- Maps: `hud_case_number` → `source_id`, `asking_price or list_price` → `price`,
+  `bedrooms` → `beds`
+- Runs `screen_property(hud_property, criteria)` immediately
+
+### create_from_usda(usda_property, user) → (PipelineProperty, created)
+- Same pattern, using `usda_case_number` → `source_id`
+
+## Template Patterns
+
+Both HUD and USDA templates follow the VRM list/detail pattern:
+- `list.html`: state filter form, property table, "Add to Pipeline" button per row
+- `detail.html`: property card with full details, "Add to Pipeline" form
+- "Add to Pipeline" posts to `pipeline_add_from_source` with `source_type` and `source_id`

--- a/docs/feature/disc-4/spec.md
+++ b/docs/feature/disc-4/spec.md
@@ -1,0 +1,38 @@
+# Specification: DISC-4 — HUD/USDA Property List & Detail Views
+
+## Problem Statement
+
+HUD and USDA properties are now ingested into HudProperty and UsdaProperty
+models, and they can be screened via the pipeline service. However, there are
+no dedicated views to browse or inspect these properties, and no "Add to
+Pipeline" button to move them into the user's pipeline.
+
+VRM properties already have `vrm_properties_list` and detail views with an
+"Add to Pipeline" button. HUD and USDA need equivalent views.
+
+## Scope
+
+| In scope | Out of scope |
+|---|---|
+| `hud_property_list` view | Filtering beyond state/ZIP (future) |
+| `hud_property_detail` view | Batch screening from list view |
+| `usda_property_list` view | Pagination (beyond basic queryset) |
+| `usda_property_detail` view | Complex template styling |
+| Extend `pipeline_add_from_source` for HUD/USDA |  |
+| `create_from_hud()` / `create_from_usda()` service functions |  |
+| List and detail templates |  |
+
+## Dependencies
+
+- DISC-1 (HudProperty model with asking_price)
+- DISC-2 (UsdaProperty model — status choices)
+- DISC-3 (screening support for HUD/USDA)
+
+## Acceptance Criteria
+
+| # | Criterion | test_type |
+|---|---|---|
+| AC1 | hud_property_list view returns 200 | unit |
+| AC2 | "Add to Pipeline" POST creates PipelineProperty with source_type='hud' | unit |
+| AC3 | usda_property_list view returns 200 | unit |
+| AC4 | "Add to Pipeline" POST creates PipelineProperty with source_type='usda' | unit |

--- a/templates/hud_properties/detail.html
+++ b/templates/hud_properties/detail.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% load static %}
+{% block title %}HUD Property {{ hud_property.hud_case_number }}{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{% url 'hud_property_list' %}">HUD Properties</a></li>
+    <li class="breadcrumb-item active">{{ hud_property.hud_case_number }}</li>
+  </ol>
+</nav>
+
+<div class="card">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <h2 class="h4 mb-0">{{ hud_property.address }}</h2>
+    <span class="badge bg-{% if hud_property.status == 'active' %}success{% elif hud_property.status == 'sold' %}secondary{% else %}info{% endif %} fs-6">{{ hud_property.get_status_display }}</span>
+  </div>
+  <div class="card-body">
+    <div class="row">
+      <div class="col-md-6">
+        <table class="table table-sm">
+          <tr><th>Case Number</th><td>{{ hud_property.hud_case_number }}</td></tr>
+          <tr><th>Address</th><td>{{ hud_property.address }}</td></tr>
+          <tr><th>City</th><td>{{ hud_property.city }}</td></tr>
+          <tr><th>State</th><td>{{ hud_property.state }}</td></tr>
+          <tr><th>ZIP</th><td>{{ hud_property.zip_code }}</td></tr>
+          <tr><th>County</th><td>{{ hud_property.county|default:"-" }}</td></tr>
+        </table>
+      </div>
+      <div class="col-md-6">
+        <table class="table table-sm">
+          <tr><th>Asking Price</th><td>{% if hud_property.asking_price %}${{ hud_property.asking_price|floatformat:2 }}{% else %}-{% endif %}</td></tr>
+          <tr><th>List Price</th><td>{% if hud_property.list_price %}${{ hud_property.list_price|floatformat:2 }}{% else %}-{% endif %}</td></tr>
+          <tr><th>Bedrooms</th><td>{{ hud_property.bedrooms|default:"-" }}</td></tr>
+          <tr><th>Bathrooms</th><td>{{ hud_property.bathrooms|default:"-" }}</td></tr>
+          <tr><th>Square Feet</th><td>{{ hud_property.square_feet|default:"-" }}</td></tr>
+          <tr><th>Property Type</th><td>{{ hud_property.property_type|default:"-" }}</td></tr>
+          <tr><th>Insured Status</th><td>{{ hud_property.get_insured_status_display|default:"-" }}</td></tr>
+        </table>
+      </div>
+    </div>
+
+    {% if hud_property.description %}
+    <div class="mt-3">
+      <h5>Description</h5>
+      <p>{{ hud_property.description }}</p>
+    </div>
+    {% endif %}
+
+    <div class="mt-4">
+      <form method="post" action="{% url 'pipeline_add_from_source' %}">
+        {% csrf_token %}
+        <input type="hidden" name="source_type" value="hud">
+        <input type="hidden" name="source_id" value="{{ hud_property.hud_case_number }}">
+        <input type="hidden" name="next" value="{% url 'hud_property_detail' hud_property.pk %}">
+        <button type="submit" class="btn btn-primary">+ Add to Pipeline</button>
+      </form>
+    </div>
+  </div>
+  <div class="card-footer text-muted">
+    Last updated: {{ hud_property.updated_at|date:"M d, Y H:i" }}
+  </div>
+</div>
+{% endblock %}

--- a/templates/hud_properties/list.html
+++ b/templates/hud_properties/list.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}
+{% load static %}
+{% block title %}HUD Properties{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">HUD Homestore Properties</h1>
+  <span class="badge bg-secondary">{{ total_count }} total / {{ filtered_count }} shown</span>
+</div>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <form method="get" class="row g-3 align-items-end">
+      <div class="col-md-4">
+        <label for="state" class="form-label">State</label>
+        <input type="text" name="state" id="state" class="form-control"
+               placeholder="e.g. TX" maxlength="2" pattern="[A-Za-z]{2}"
+               value="{{ selected_state }}">
+      </div>
+      <div class="col-md-2">
+        <button type="submit" class="btn btn-primary w-100">Filter</button>
+      </div>
+      {% if selected_state %}
+      <div class="col-md-2">
+        <a href="{% url 'hud_property_list' %}" class="btn btn-outline-secondary w-100">Clear</a>
+      </div>
+      {% endif %}
+    </form>
+  </div>
+</div>
+
+<div class="table-responsive">
+  <table class="table table-striped table-hover align-middle">
+    <thead class="table-dark">
+      <tr>
+        <th>Case #</th>
+        <th>Address</th>
+        <th>City</th>
+        <th>State</th>
+        <th>Price</th>
+        <th>Beds</th>
+        <th>Baths</th>
+        <th>Sq Ft</th>
+        <th>Status</th>
+        <th>Listed</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for prop in hud_properties %}
+      <tr>
+        <td><a href="{% url 'hud_property_detail' prop.pk %}">{{ prop.hud_case_number }}</a></td>
+        <td>{{ prop.address }}</td>
+        <td>{{ prop.city }}</td>
+        <td>{{ prop.state }}</td>
+        <td>{% if prop.asking_price %}${{ prop.asking_price|floatformat:0 }}{% elif prop.list_price %}${{ prop.list_price|floatformat:0 }}{% else %}-{% endif %}</td>
+        <td>{{ prop.bedrooms|default:"-" }}</td>
+        <td>{{ prop.bathrooms|default:"-" }}</td>
+        <td>{{ prop.square_feet|default:"-" }}</td>
+        <td><span class="badge bg-{% if prop.status == 'active' %}success{% elif prop.status == 'sold' %}secondary{% elif prop.status == 'pending' %}warning{% else %}info{% endif %}">{{ prop.get_status_display }}</span></td>
+        <td>{{ prop.scraped_at|date:"M d, Y" }}</td>
+        <td>
+          <form method="post" action="{% url 'pipeline_add_from_source' %}" class="pipeline-inline-form">
+            {% csrf_token %}
+            <input type="hidden" name="source_type" value="hud">
+            <input type="hidden" name="source_id" value="{{ prop.hud_case_number }}">
+            <input type="hidden" name="next" value="{% url 'hud_property_list' %}{% if selected_state %}?state={{ selected_state }}{% endif %}">
+            <button type="submit" class="btn btn-sm btn-outline-primary">+ Add to Pipeline</button>
+          </form>
+        </td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="11" class="text-center text-muted py-4">No HUD properties found.</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/templates/usda_properties/detail.html
+++ b/templates/usda_properties/detail.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% load static %}
+{% block title %}USDA Property {{ usda_property.usda_case_number }}{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{% url 'usda_property_list' %}">USDA Properties</a></li>
+    <li class="breadcrumb-item active">{{ usda_property.usda_case_number }}</li>
+  </ol>
+</nav>
+
+<div class="card">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <h2 class="h4 mb-0">{{ usda_property.address }}</h2>
+    <span class="badge bg-{% if usda_property.status == 'active' %}success{% elif usda_property.status == 'sold' %}secondary{% else %}info{% endif %} fs-6">{{ usda_property.get_status_display }}</span>
+  </div>
+  <div class="card-body">
+    <div class="row">
+      <div class="col-md-6">
+        <table class="table table-sm">
+          <tr><th>Case Number</th><td>{{ usda_property.usda_case_number }}</td></tr>
+          <tr><th>Address</th><td>{{ usda_property.address }}</td></tr>
+          <tr><th>City</th><td>{{ usda_property.city }}</td></tr>
+          <tr><th>State</th><td>{{ usda_property.state }}</td></tr>
+          <tr><th>ZIP</th><td>{{ usda_property.zip_code }}</td></tr>
+          <tr><th>County</th><td>{{ usda_property.county|default:"-" }}</td></tr>
+        </table>
+      </div>
+      <div class="col-md-6">
+        <table class="table table-sm">
+          <tr><th>List Price</th><td>{% if usda_property.list_price %}${{ usda_property.list_price|floatformat:2 }}{% else %}-{% endif %}</td></tr>
+          <tr><th>Bedrooms</th><td>{{ usda_property.bedrooms|default:"-" }}</td></tr>
+          <tr><th>Bathrooms</th><td>{{ usda_property.bathrooms|default:"-" }}</td></tr>
+          <tr><th>Square Feet</th><td>{{ usda_property.square_feet|default:"-" }}</td></tr>
+          <tr><th>Lot Size (Acres)</th><td>{{ usda_property.lot_size_acres|default:"-" }}</td></tr>
+          <tr><th>Property Type</th><td>{{ usda_property.property_type|default:"-" }}</td></tr>
+        </table>
+      </div>
+    </div>
+
+    {% if usda_property.description %}
+    <div class="mt-3">
+      <h5>Description</h5>
+      <p>{{ usda_property.description }}</p>
+    </div>
+    {% endif %}
+
+    <div class="mt-4">
+      <form method="post" action="{% url 'pipeline_add_from_source' %}">
+        {% csrf_token %}
+        <input type="hidden" name="source_type" value="usda">
+        <input type="hidden" name="source_id" value="{{ usda_property.usda_case_number }}">
+        <input type="hidden" name="next" value="{% url 'usda_property_detail' usda_property.pk %}">
+        <button type="submit" class="btn btn-primary">+ Add to Pipeline</button>
+      </form>
+    </div>
+  </div>
+  <div class="card-footer text-muted">
+    Last updated: {{ usda_property.updated_at|date:"M d, Y H:i" }}
+  </div>
+</div>
+{% endblock %}

--- a/templates/usda_properties/list.html
+++ b/templates/usda_properties/list.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}
+{% load static %}
+{% block title %}USDA Properties{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">USDA Rural Development Properties</h1>
+  <span class="badge bg-secondary">{{ total_count }} total / {{ filtered_count }} shown</span>
+</div>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <form method="get" class="row g-3 align-items-end">
+      <div class="col-md-4">
+        <label for="state" class="form-label">State</label>
+        <input type="text" name="state" id="state" class="form-control"
+               placeholder="e.g. TX" maxlength="2" pattern="[A-Za-z]{2}"
+               value="{{ selected_state }}">
+      </div>
+      <div class="col-md-2">
+        <button type="submit" class="btn btn-primary w-100">Filter</button>
+      </div>
+      {% if selected_state %}
+      <div class="col-md-2">
+        <a href="{% url 'usda_property_list' %}" class="btn btn-outline-secondary w-100">Clear</a>
+      </div>
+      {% endif %}
+    </form>
+  </div>
+</div>
+
+<div class="table-responsive">
+  <table class="table table-striped table-hover align-middle">
+    <thead class="table-dark">
+      <tr>
+        <th>Case #</th>
+        <th>Address</th>
+        <th>City</th>
+        <th>State</th>
+        <th>Price</th>
+        <th>Beds</th>
+        <th>Baths</th>
+        <th>Sq Ft</th>
+        <th>Acres</th>
+        <th>Status</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for prop in usda_properties %}
+      <tr>
+        <td><a href="{% url 'usda_property_detail' prop.pk %}">{{ prop.usda_case_number }}</a></td>
+        <td>{{ prop.address }}</td>
+        <td>{{ prop.city }}</td>
+        <td>{{ prop.state }}</td>
+        <td>{% if prop.list_price %}${{ prop.list_price|floatformat:0 }}{% else %}-{% endif %}</td>
+        <td>{{ prop.bedrooms|default:"-" }}</td>
+        <td>{{ prop.bathrooms|default:"-" }}</td>
+        <td>{{ prop.square_feet|default:"-" }}</td>
+        <td>{{ prop.lot_size_acres|default:"-" }}</td>
+        <td><span class="badge bg-{% if prop.status == 'active' %}success{% elif prop.status == 'sold' %}secondary{% elif prop.status == 'pending' %}warning{% else %}info{% endif %}">{{ prop.get_status_display }}</span></td>
+        <td>
+          <form method="post" action="{% url 'pipeline_add_from_source' %}" class="pipeline-inline-form">
+            {% csrf_token %}
+            <input type="hidden" name="source_type" value="usda">
+            <input type="hidden" name="source_id" value="{{ prop.usda_case_number }}">
+            <input type="hidden" name="next" value="{% url 'usda_property_list' %}{% if selected_state %}?state={{ selected_state }}{% endif %}">
+            <button type="submit" class="btn btn-sm btn-outline-primary">+ Add to Pipeline</button>
+          </form>
+        </td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="11" class="text-center text-muted py-4">No USDA properties found.</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## What this PR does

Adds HUD and USDA property list/detail views with "Add to Pipeline" button, plus the service-layer `create_from_hud()` and `create_from_usda()` functions that extend the existing `pipeline_add_from_source` view.

## Top 2–3 failure modes

1. **Template styling** — uses basic Bootstrap classes (no custom design system). Follows VRM list template pattern.
2. **No rent data on HUD/USDA** — correct by design; screening will skip yield/PTR criteria
3. **No batch screening from list view** — future enhancement

## Tests cover this change

- `core/tests/test_discovery_views.py` — 4 tests (HUD list 200, HUD add to pipeline, USDA list 200, USDA add to pipeline)

## Architecture check

- [x] No financial math directly in views or models
- [x] No external API calls in views
- [x] No `float` used for currency — Decimal throughout
- [x] No `any` type in new code

## Checklist

- [x] `ruff check . && ruff format --check . && pytest -q` passes
- [x] PR is < 400 changed lines
- [x] No secrets or credentials in any changed file
- [x] `docs/` updated