### PR TITLE
fix(nav): change Rehab & Lease link from pipeline_list to leasing_list

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -52,7 +52,7 @@
           My Pipeline
           <span class="sub-label">Track all pipeline properties</span>
         </a>
-        <a href="{% url 'pipeline_list' %}" class="nav-dropdown-item {% if request.resolver_match.url_name == 'pipeline_list' %}active{% endif %}" role="menuitem">
+        <a href="{% url 'leasing_list' %}" class="nav-dropdown-item {% if request.resolver_match.url_name == 'leasing_list' %}active{% endif %}" role="menuitem">
           Rehab &amp; Lease
           <span class="sub-label">Renovation and leasing pipeline</span>
         </a>


### PR DESCRIPTION
## What this PR does

Fixes a nav bug: the "Rehab & Lease" dropdown item was pointing to `pipeline_list` (same as "My Pipeline"). Changed to `leasing_list` which renders the leasing pipeline page.

## Validation
- python manage.py check - passes
- No two dropdown items link to the same URL
- Active class now uses leasing_list so the item highlights correctly
- djLint linting - passes
- pytest - passes

## One-line fix

Changed href from pipeline_list to leasing_list, and changed the active class condition from url_name == pipeline_list to url_name == leasing_list