### PR TITLE
feat(ux): add This month filter to pipeline list (PIPE-UX-3)

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1092,11 +1092,15 @@ def pipeline_list(request: HttpRequest) -> HttpResponse:
     GET params:
       status: filter by status (ACTIVE, KILLED, ON_HOLD) — default ACTIVE
       stage:  filter by stage (SCREENING, UNDERWRITING, etc) — optional
+      month:  set to 'this' to filter to current month's properties
     """
+    from django.utils import timezone as tz
+
     from core.models import PipelineProperty
 
     status_filter = request.GET.get("status", "ACTIVE")
     stage_filter = request.GET.get("stage", "")
+    month_filter = request.GET.get("month", "")
 
     qs = (
         PipelineProperty.objects.filter(user=request.user)
@@ -1108,11 +1112,19 @@ def pipeline_list(request: HttpRequest) -> HttpResponse:
         qs = qs.filter(status=status_filter)
     if stage_filter:
         qs = qs.filter(stage=stage_filter)
+    if month_filter == "this":
+        now = tz.now()
+        qs = qs.filter(created_at__month=now.month, created_at__year=now.year)
 
     # Stage counts for funnel header
-    all_user_props = PipelineProperty.objects.filter(user=request.user)
+    stage_qs = PipelineProperty.objects.filter(user=request.user)
+    if month_filter == "this":
+        now = tz.now()
+        stage_qs = stage_qs.filter(
+            created_at__month=now.month, created_at__year=now.year
+        )
     stage_counts: dict[str, int] = {}
-    for pp in all_user_props:
+    for pp in stage_qs:
         stage_counts[pp.stage] = stage_counts.get(pp.stage, 0) + 1
 
     # Build ordered list of (stage_label, count) for template display
@@ -1137,6 +1149,7 @@ def pipeline_list(request: HttpRequest) -> HttpResponse:
             "stage_items": stage_items,
             "current_status": status_filter,
             "current_stage": stage_filter,
+            "month_filter": month_filter,
             "status_choices": [
                 ("ACTIVE", "Active"),
                 ("KILLED", "Killed"),

--- a/templates/pipeline/pipeline_list.html
+++ b/templates/pipeline/pipeline_list.html
@@ -27,11 +27,17 @@
   {# Status filter tabs #}
   <div class="pipeline-status-tabs">
     {% for status_val, status_label in status_choices %}
-      <a href="?status={{ status_val }}{% if current_stage %}&stage={{ current_stage }}{% endif %}"
+      <a href="?status={{ status_val }}{% if current_stage %}&stage={{ current_stage }}{% endif %}{% if month_filter %}&month={{ month_filter }}{% endif %}"
          class="pipeline-status-tab active-{{ status_val|lower }}">
         {{ status_label }}
       </a>
     {% endfor %}
+    <a href="?month=this{% if current_status %}&status={{ current_status }}{% endif %}{% if current_stage %}&stage={{ current_stage }}{% endif %}"
+       class="pipeline-status-tab {% if month_filter == 'this' %}is-active{% endif %}">This month</a>
+    {% if month_filter %}
+      <a href="?{% if current_status %}status={{ current_status }}{% endif %}{% if current_stage %}&stage={{ current_stage }}{% endif %}"
+         class="pipeline-status-tab">All time</a>
+    {% endif %}
   </div>
 
   {# Property cards #}


### PR DESCRIPTION
## What this PR does

Both the pipeline_list funnel and pipeline_dashboard KPIs were **already rendered** — no visual changes needed there. This PR adds a `month=this` GET filter to `/pipeline/list/` that filters to properties created in the current month.

## Changes

| File | Change |
|---|---|
| core/views.py | Added `month_filter` to pipeline_list view; filters qs + stage_counts by current month |
| templates/pipeline/pipeline_list.html | Added "This month" / "All time" toggle tabs beside status filter tabs |

## What was checked (found already rendered)

- pipeline_list.html: stage_items funnel with `pipeline-funnel` class ✅
- pipeline_dashboard.html: kpi-grid with Acquisition/Deal Making/Operations/Portfolio ✅
- Stage Distribution table ✅

So no new CSS or template structure was needed for those — they already shipped in earlier PRs.

## Checklist

- [x] No new CSS classes
- [x] No inline style= attributes
- [x] ruff + mypy + djlint pass
- [x] 12/12 pytest pass