### PR TITLE
feat(ux): add source_type filter chips to pipeline list (PIPE-UX-5)

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1093,6 +1093,7 @@ def pipeline_list(request: HttpRequest) -> HttpResponse:
       status: filter by status (ACTIVE, KILLED, ON_HOLD) — default ACTIVE
       stage:  filter by stage (SCREENING, UNDERWRITING, etc) — optional
       month:  set to 'this' to filter to current month's properties
+      source: filter by source_type (vrm, hud, usda, etc) — optional
     """
     from django.utils import timezone as tz
 
@@ -1101,6 +1102,7 @@ def pipeline_list(request: HttpRequest) -> HttpResponse:
     status_filter = request.GET.get("status", "ACTIVE")
     stage_filter = request.GET.get("stage", "")
     month_filter = request.GET.get("month", "")
+    source_filter = request.GET.get("source", "")
 
     qs = (
         PipelineProperty.objects.filter(user=request.user)
@@ -1115,6 +1117,8 @@ def pipeline_list(request: HttpRequest) -> HttpResponse:
     if month_filter == "this":
         now = tz.now()
         qs = qs.filter(created_at__month=now.month, created_at__year=now.year)
+    if source_filter:
+        qs = qs.filter(source_type=source_filter)
 
     # Stage counts for funnel header
     stage_qs = PipelineProperty.objects.filter(user=request.user)
@@ -1123,6 +1127,8 @@ def pipeline_list(request: HttpRequest) -> HttpResponse:
         stage_qs = stage_qs.filter(
             created_at__month=now.month, created_at__year=now.year
         )
+    if source_filter:
+        stage_qs = stage_qs.filter(source_type=source_filter)
     stage_counts: dict[str, int] = {}
     for pp in stage_qs:
         stage_counts[pp.stage] = stage_counts.get(pp.stage, 0) + 1
@@ -1150,6 +1156,8 @@ def pipeline_list(request: HttpRequest) -> HttpResponse:
             "current_status": status_filter,
             "current_stage": stage_filter,
             "month_filter": month_filter,
+            "current_source": source_filter,
+            "source_choices": [(c.value, c.label) for c in PipelineProperty.SourceType],
             "status_choices": [
                 ("ACTIVE", "Active"),
                 ("KILLED", "Killed"),

--- a/templates/pipeline/pipeline_list.html
+++ b/templates/pipeline/pipeline_list.html
@@ -40,6 +40,16 @@
     {% endif %}
   </div>
 
+  {# Source type filter chips #}
+  <div class="chip-group">
+    <a href="?status={{ current_status }}{% if current_stage %}&stage={{ current_stage }}{% endif %}{% if month_filter %}&month={{ month_filter }}{% endif %}"
+       class="chip {% if not current_source %}is-active{% endif %}">All</a>
+    {% for val, label in source_choices %}
+    <a href="?status={{ current_status }}&source={{ val }}{% if current_stage %}&stage={{ current_stage }}{% endif %}{% if month_filter %}&month={{ month_filter }}{% endif %}"
+       class="chip {% if current_source == val %}is-active{% endif %}">{{ label }}</a>
+    {% endfor %}
+  </div>
+
   {# Property cards #}
   {% if properties %}
     <div class="pipeline-cards">


### PR DESCRIPTION
## What this PR does

Adds a `?source=` GET filter to `/pipeline/list/` that filters by `source_type` (VRM, HUD, USDA, etc). A chip-group row renders all source choices above the property cards.

## Changes

| File | Change |
|---|---|
| `core/views.py` | Added `source_filter` GET param; passes `current_source` + `source_choices` to template; filters both qs and stage_counts |
| `templates/pipeline/pipeline_list.html` | Added chip-group with All + each source type above property cards |

## Usage

- `/pipeline/list/` — shows all
- `/pipeline/list/?source=vrm` — only VRM
- `/pipeline/list/?source=hud` — only HUD
- Active chip gets `is-active` class

## Checklist

- [x] One-liner view change (filter + context)
- [x] Chip-group row, no JS needed (GET param approach)
- [x] No new CSS classes beyond existing chip/chip-group/is-active
- [x] ruff + mypy + djlint pass
- [x] 12/12 pytest pass