### PR TITLE
feat(ux): add experimental score disclaimer banner to growth areas (GA-UX-1)

### DIFF
--- a/templates/growth_areas.html
+++ b/templates/growth_areas.html
@@ -21,6 +21,8 @@
   </div>
 </div>
 
+<div class="message message-warning">Growth area scores use an experimental weighting model. Weights are a hypothesis — not research-validated. Verify markets independently before investing.</div>
+
 {% if growth_page %}
   {% if data_source == "snapshot" %}
     <!-- MarketSnapshot fallback table -->

--- a/templates/growth_explorer.html
+++ b/templates/growth_explorer.html
@@ -169,6 +169,7 @@
 
 <!-- Results Section -->
 <div id="results-section"{% if results is None and not error %} hidden{% endif %}>
+  <div class="message message-warning">Growth area scores use an experimental weighting model. Weights are a hypothesis — not research-validated. Verify markets independently before investing.</div>
 {% if results is not None %}
   <div class="mt-section">
     <div class="page-header">


### PR DESCRIPTION
## What this PR does

Adds an experimental-score disclaimer banner to both growth area views. Uses existing `message message-warning` CSS classes — no new CSS, no inline styles.

## Changes

| File | Change |
|---|---|
| `templates/growth_areas.html` | Added warning banner below page header, above the table |
| `templates/growth_explorer.html` | Added warning banner at top of results section |

## Banner text

> "Growth area scores use an experimental weighting model. Weights are a hypothesis — not research-validated. Verify markets independently before investing."

## Checklist

- [x] No new CSS classes
- [x] No inline style=
- [x] No hardcoded hex colors
- [x] 20/20 growth area tests pass