### PR TITLE
feat(ux): add composite score breakdown rows to growth area lists (GA-UX-2)

### DIFF
--- a/templates/growth_areas.html
+++ b/templates/growth_areas.html
@@ -80,7 +80,22 @@
               <td class="col-right num">{{ ga.median_income_growth|mul:100|floatformat:2 }}%</td>
               <td class="col-right">{{ ga.housing_demand_index }}</td>
               <td class="col-right score-num num-good">{{ ga.composite_score|default_if_none:""|floatformat:2 }}</td>
-              <td><a href="{% url 'vrm_properties_list' %}?state={{ ga.state }}" class="btn">Foreclosures</a></td>
+              <td><a href="{% url 'vrm_properties_list' %}?state={{ ga.state }}" class="btn">Foreclosures</a> <button class="btn" onclick="var r=document.getElementById('breakdown-{{ forloop.counter0 }}');r.hidden=!r.hidden">Score</button></td>
+            </tr>
+            <tr id="breakdown-{{ forloop.counter0 }}" hidden>
+              <td colspan="10">
+                <table class="data-table">
+                  <thead><tr><th>Component</th><th>Value</th><th>Weight</th></tr></thead>
+                  <tbody>
+                    <tr><td>Employment growth</td><td>{{ ga.employment_growth_rate|mul:100|floatformat:2 }}%</td><td>35%</td></tr>
+                    <tr><td>Population growth</td><td>{{ ga.population_growth_rate|mul:100|floatformat:2 }}%</td><td>20%</td></tr>
+                    <tr><td>Income growth</td><td>{{ ga.median_income_growth|mul:100|floatformat:2 }}%</td><td>20%</td></tr>
+                    <tr><td>Supply constraint</td><td>{{ ga.supply_constraint_index }}</td><td>15%</td></tr>
+                    <tr><td>Housing demand</td><td>{{ ga.housing_demand_index }}</td><td>10%</td></tr>
+                  </tbody>
+                </table>
+                <p class="page-sub">ACS vintage: auto-detected (2024 or latest available) &middot; Data timestamp: {{ ga.data_timestamp|date:"Y-m-d" }}</p>
+              </td>
             </tr>
           {% endfor %}
         </tbody>

--- a/templates/growth_explorer.html
+++ b/templates/growth_explorer.html
@@ -230,6 +230,22 @@
               <td>
                 <a href="{% url 'vrm_properties_list' %}?state={{ r.growth_area.state }}" class="btn">View Foreclosures</a>
                 <button type="submit" name="pipeline_city" value="{{ r.place_name }}" class="btn" title="Run property discovery pipeline for {{ r.place_name }}, {{ r.growth_area.state }}">🔍 Discover</button>
+                <button type="button" class="btn" onclick="var r=document.getElementById('ge-breakdown-{{ forloop.counter0 }}');r.hidden=!r.hidden">Score</button>
+              </td>
+            </tr>
+            <tr id="ge-breakdown-{{ forloop.counter0 }}" hidden>
+              <td colspan="11">
+                <table class="data-table">
+                  <thead><tr><th>Component</th><th>Value</th><th>Weight</th></tr></thead>
+                  <tbody>
+                    <tr><td>Employment growth</td><td>{{ r.growth_area.employment_growth_rate|mul:100|floatformat:2 }}%</td><td>35%</td></tr>
+                    <tr><td>Population growth</td><td>{{ r.growth_area.population_growth_rate|mul:100|floatformat:2 }}%</td><td>20%</td></tr>
+                    <tr><td>Income growth</td><td>{{ r.growth_area.median_income_growth|mul:100|floatformat:2 }}%</td><td>20%</td></tr>
+                    <tr><td>Supply constraint</td><td>{{ r.growth_area.supply_constraint_index }}</td><td>15%</td></tr>
+                    <tr><td>Housing demand</td><td>{{ r.growth_area.housing_demand_index }}</td><td>10%</td></tr>
+                  </tbody>
+                </table>
+                <p class="page-sub">ACS vintage: auto-detected (2024 or latest available) &middot; Data timestamp: {{ r.growth_area.data_timestamp|date:"Y-m-d" }}</p>
               </td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
## What this PR does

Adds a "Score" button to each growth area row in both the saved-list and explorer views. Clicking toggles an expandable detail row showing the 5 sub-components with their weights and data timestamp.

## Changes

| File | Change |
|---|---|
| `templates/growth_areas.html` | Added "Score" button + hidden breakdown row with data-table |
| `templates/growth_explorer.html` | Same |

## Breakdown table

| Component | Weight |
|---|---|
| Employment growth | 35% |
| Population growth | 20% |
| Income growth | 20% |
| Supply constraint | 15% |
| Housing demand | 10% |

Plus ACS vintage note and data timestamp.

## Checklist

- [x] No new CSS classes — data-table, page-sub exist
- [x] No inline style= (used `hidden` attribute)
- [x] No JS libraries — vanilla `element.hidden` toggle
- [x] 20/20 growth area tests pass