### PR TITLE
fix(config): add FRED_API_KEY to .env.example and settings.py (GA-FIX-1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,9 @@ ATTOM_API_KEY=your_attom_api_key_here
 # ZIP demographics (population, income, growth) — https://api.census.gov
 CENSUS_API_KEY=your_census_api_key_here
 
+# FRED economic data (employment growth, unemployment) — https://fred.stlouisfed.org/docs/api/api_key.html
+FRED_API_KEY=your_fred_api_key_here
+
 # Unemployment, wage data — https://data.bls.gov/registrationEngine/
 BLS_API_KEY=your_bls_api_key_here
 

--- a/investor_app/settings.py
+++ b/investor_app/settings.py
@@ -250,6 +250,9 @@ GROWTH_AREAS_CACHE_DURATION = 86400  # 24 hours
 # significantly by market, contractor, and property condition.
 # Override individual values via env vars: REHAB_COST_COSMETIC,
 # REHAB_COST_MODERATE, REHAB_COST_FULL_GUT (dollar amounts, e.g. "15").
+# FRED API key for economic data (employment growth, unemployment)
+FRED_API_KEY: str = env("FRED_API_KEY", default="")
+
 REHAB_COST_PER_SQFT: dict[str, Decimal] = {
     "cosmetic": Decimal(
         env("REHAB_COST_COSMETIC", default="15")


### PR DESCRIPTION
## What this PR does

Adds the `FRED_API_KEY` environment variable to `.env.example` and `settings.py`. The key is already used by `FREDAdapter` in `core/integrations/sources/fred_adapter.py` (reads from `os.getenv("FRED_API_KEY")`) but was undocumented and not accessible via `settings.FRED_API_KEY`.

## Changes

| File | Change |
|---|---|
| `.env.example` | Added `FRED_API_KEY` to API keys section |
| `investor_app/settings.py` | Added `FRED_API_KEY = env("FRED_API_KEY", default="")` |

## Acceptance

- [x] `grep FRED_API_KEY .env.example` — returns match
- [x] `settings.FRED_API_KEY` — accessible from Django
- [x] No real keys committed