### PR TITLE
feat: wire ATTOM to discovery, add county pipeline support, add data confidence

### DIFF
--- a/core/migrations/0036_seed_attom_source.py
+++ b/core/migrations/0036_seed_attom_source.py
@@ -1,0 +1,38 @@
+"""Add ATTOM Data Solutions as a property source."""
+
+from __future__ import annotations
+
+from django.db import migrations
+
+ATT = "attom"
+
+
+def seed_attom(apps, schema_editor):  # type: ignore[no-untyped-def]
+    PropertySource = apps.get_model("core", "PropertySource")
+    PropertySource.objects.update_or_create(
+        source_type=ATT,
+        defaults={
+            "source_type": ATT,
+            "name": "ATTOM Preforeclosures",
+            "description": "Pre-foreclosure notices (NOD, NTS, Lis Pendens) from ATTOM Data Solutions. Requires a paid API key (ATTOM_API_KEY). Covers property address, lender, trustee, sale date, and unpaid balance.",
+            "website_url": "https://api.attomdata.com",
+            "is_free": False,
+            "is_active": True,
+            "sort_order": 8,
+        },
+    )
+
+
+def remove_attom(apps, schema_editor):  # type: ignore[no-untyped-def]
+    PropertySource = apps.get_model("core", "PropertySource")
+    PropertySource.objects.filter(source_type=ATT).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0035_add_usda_removed_status"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_attom, remove_attom),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -730,6 +730,33 @@ class GrowthArea(models.Model):
         )
         return score
 
+    @property
+    def data_confidence(self) -> int:
+        """Confidence score 0-100 based on how many data points are real vs defaults.
+
+        Each of the 5 GACS components is scored:
+        - real value from API → 20 points
+        - default/placeholder  → 0 points
+        """
+        score = 0
+        # population_growth_rate: required field, always real
+        score += 20
+        # employment_growth_rate: nullable — if it's None, FRED data was missing
+        if self.employment_growth_rate is not None:
+            score += 20
+        # median_income_growth: required field, always real
+        score += 20
+        # housing_demand_index: default is 50 — if it's 50, may be placeholder
+        if self.housing_demand_index != 50:
+            score += 20
+        # supply_constraint_index: default is 50
+        if (
+            self.supply_constraint_index is not None
+            and self.supply_constraint_index != 50
+        ):
+            score += 20
+        return score
+
     def save(self, *args, **kwargs):
         """Precompute composite_score on save."""
         self.composite_score = self._compute_composite_score()

--- a/core/services/pipeline.py
+++ b/core/services/pipeline.py
@@ -454,6 +454,69 @@ def create_from_usda(
     return pp, True
 
 
+def create_from_county_notice(
+    county_notice: Any,
+    user: Any,
+) -> Tuple[Any, bool]:
+    """Create a PipelineProperty from a CountyForeclosureNotice and run screening.
+
+    Handles both ATTOM preforeclosure data (stored as CountyForeclosureNotice)
+    and county-scraped notices. No rent data available for these sources,
+    so yield/PTR criteria are skipped during screening.
+
+    Args:
+        county_notice: CountyForeclosureNotice instance.
+        user: Django User who owns this pipeline entry.
+
+    Returns:
+        Tuple of (PipelineProperty, created).
+    """
+    from core.models import CountyForeclosureNotice, PipelineProperty, ScreeningCriteria
+    from core.services.screening import screen_property
+
+    if not isinstance(county_notice, CountyForeclosureNotice):
+        raise TypeError("Expected CountyForeclosureNotice instance")
+
+    criteria, _ = ScreeningCriteria.objects.get_or_create(user=user)
+
+    pp, created = PipelineProperty.objects.get_or_create(
+        user=user,
+        source_type=PipelineProperty.SourceType.COUNTY,
+        source_id=str(county_notice.case_number),
+        defaults={
+            "address": county_notice.address or "",
+            "address_hash": "",
+            "stage": PipelineProperty.Stage.DISCOVERED,
+            "status": PipelineProperty.Status.ACTIVE,
+            "price": county_notice.unpaid_balance,
+            "estimated_rent": None,
+            "beds": None,
+            "year_built": None,
+            "discovered_at": timezone.now(),
+        },
+    )
+
+    if not created:
+        return pp, False
+
+    # Run screening immediately
+    result = screen_property(pp, criteria, source_record=county_notice)
+
+    pp.screening_passed = result.passed
+    pp.screening_at = timezone.now()
+    pp.stage = PipelineProperty.Stage.SCREENING
+    pp.save(
+        update_fields=[
+            "screening_passed",
+            "screening_at",
+            "stage",
+            "updated_at",
+        ]
+    )
+
+    return pp, True
+
+
 # ── Conversion to Property record ──────────────────────────────────────────────
 
 

--- a/core/views.py
+++ b/core/views.py
@@ -1398,6 +1398,55 @@ def pipeline_add_from_source(request: HttpRequest) -> HttpResponse:
 
         return redirect("pipeline_detail", pk=pp.pk)
 
+    if source_type in ("attom", "county"):
+        from core.integrations.sources.attom_preforeclosure import (
+            fetch_attom_preforeclosure,
+        )
+        from core.models import CountyForeclosureNotice
+        from core.services.pipeline import create_from_county_notice
+
+        if source_type == "attom":
+            # For ATTOM, source_id is a ZIP code — fetch via API, then upsert
+            notices = fetch_attom_preforeclosure(zip_code=source_id)
+            if not notices:
+                messages.warning(
+                    request, "No ATTOM preforeclosure notices found for that ZIP."
+                )
+                return redirect(next_url)
+
+            count = 0
+            for notice_data in notices:
+                notice_data.pop("scraped_at", None)
+                notice_data.pop("last_seen_at", None)
+                cn, _ = CountyForeclosureNotice.objects.update_or_create(
+                    case_number=notice_data["case_number"],
+                    county=notice_data.get("county", ""),
+                    state=notice_data.get("state", ""),
+                    defaults=notice_data,
+                )
+                pp, created = create_from_county_notice(cn, request.user)
+                if created:
+                    count += 1
+
+            messages.success(request, f"{count} ATTOM notice(s) added to pipeline.")
+            return redirect("pipeline_list")
+        else:
+            # county: source_id is a CountyForeclosureNotice pk
+            try:
+                cn = CountyForeclosureNotice.objects.get(pk=int(source_id))
+            except (CountyForeclosureNotice.DoesNotExist, ValueError, TypeError):
+                messages.error(request, "County notice not found")
+                return redirect(next_url)
+
+            pp, created = create_from_county_notice(cn, request.user)
+
+            if created:
+                messages.success(request, "County notice added to pipeline.")
+            else:
+                messages.info(request, "Already in your pipeline")
+
+            return redirect("pipeline_detail", pk=pp.pk)
+
     messages.error(request, f"Unknown source type: {source_type}")
     return redirect(next_url)
 

--- a/templates/growth_areas.html
+++ b/templates/growth_areas.html
@@ -94,7 +94,7 @@
                     <tr><td>Housing demand</td><td>{{ ga.housing_demand_index }}</td><td>10%</td></tr>
                   </tbody>
                 </table>
-                <p class="page-sub">ACS vintage: auto-detected (2024 or latest available) &middot; Data timestamp: {{ ga.data_timestamp|date:"Y-m-d" }}</p>
+                <p class="page-sub">ACS vintage: auto-detected (2024 or latest available) &middot; Data timestamp: {{ ga.data_timestamp|date:"Y-m-d" }} &middot; Confidence: {{ ga.data_confidence }}%</p>
               </td>
             </tr>
           {% endfor %}

--- a/templates/growth_explorer.html
+++ b/templates/growth_explorer.html
@@ -245,7 +245,7 @@
                     <tr><td>Housing demand</td><td>{{ r.growth_area.housing_demand_index }}</td><td>10%</td></tr>
                   </tbody>
                 </table>
-                <p class="page-sub">ACS vintage: auto-detected (2024 or latest available) &middot; Data timestamp: {{ r.growth_area.data_timestamp|date:"Y-m-d" }}</p>
+                <p class="page-sub">ACS vintage: auto-detected (2024 or latest available) &middot; Data timestamp: {{ r.growth_area.data_timestamp|date:"Y-m-d" }} &middot; Confidence: {{ r.growth_area.data_confidence }}%</p>
               </td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
## What this PR does

Three things that directly answer your questions:

### 1. ATTOM wired to discovery stage
Added ATTOM as a PropertySource (migration 0036). Now when a user submits a ZIP code via the Discovery page with "ATTOM Preforeclosures" selected, it calls `fetch_attom_preforeclosure()`, upserts results into `CountyForeclosureNotice`, creates `PipelineProperty` records, and runs screening — all in one flow.

### 2. County pipeline support
Created `create_from_county_notice()` service function. Both `attom` and `county` source types are now accepted by `pipeline_add_from_source`.

### 3. Growth area data confidence
Added `data_confidence` property to GrowthArea (0-100%). Each of the 5 GACS components scores 20 points if it has a real value vs a default/placeholder. Shown in the score breakdown rows as "Confidence: 80%".

## VRM foreclosures
Already connected to the pipeline! The Foreclosures list has "Add to Pipeline" per property. VRM, HUD, USDA, and now ATTOM/county notices all flow through the same screening pipeline.

## Research findings included in next section.