### PR TITLE
feat: add HUD FMR rent estimates and BLS LAUS county unemployment adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,9 @@ CENSUS_API_KEY=your_census_api_key_here
 # FRED economic data (employment growth, unemployment) — https://fred.stlouisfed.org/docs/api/api_key.html
 FRED_API_KEY=your_fred_api_key_here
 
+# HUD Fair Market Rents (rent estimates by ZIP/county) — https://www.huduser.gov/portal/dataset/fmr-api.html
+HUD_API_KEY=your_hud_api_key_here
+
 # Unemployment, wage data — https://data.bls.gov/registrationEngine/
 BLS_API_KEY=your_bls_api_key_here
 

--- a/core/integrations/market/bls_laus.py
+++ b/core/integrations/market/bls_laus.py
@@ -1,0 +1,170 @@
+"""BLS Local Area Unemployment Statistics (LAUS) — county-level.
+
+Fetches county-level unemployment rates and employment levels from
+the Bureau of Labor Statistics LAUS program.
+
+BLS series ID format for county LAUS:
+  LAUCN{SS}{CCC}0000000003  — unemployment rate (percent)
+  LAUCN{SS}{CCC}0000000005  — employment level (jobs)
+  LAUCN{SS}{CCC}0000000006  — labor force level
+  LAUCN{SS}{CCC}0000000007  — unemployed level
+
+Where SS = 2-digit state FIPS, CCC = 3-digit county FIPS.
+
+API: https://www.bls.gov/developers/
+Free API key at https://data.bls.gov/registrationEngine/
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+BLS_API_BASE = "https://api.bls.gov/publicAPI/v2/timeseries/data/"
+
+# State → 2-digit FIPS mapping (shared with bls.py)
+STATE_FIPS = {
+    "AL": "01", "AK": "02", "AZ": "04", "AR": "05", "CA": "06", "CO": "08",
+    "CT": "09", "DE": "10", "DC": "11", "FL": "12", "GA": "13", "HI": "15",
+    "ID": "16", "IL": "17", "IN": "18", "IA": "19", "KS": "20", "KY": "21",
+    "LA": "22", "ME": "23", "MD": "24", "MA": "25", "MI": "26", "MN": "27",
+    "MS": "28", "MO": "29", "MT": "30", "NE": "31", "NV": "32", "NH": "33",
+    "NJ": "34", "NM": "35", "NY": "36", "NC": "37", "ND": "38", "OH": "39",
+    "OK": "40", "OR": "41", "PA": "42", "RI": "44", "SC": "45", "SD": "46",
+    "TN": "47", "TX": "48", "UT": "49", "VT": "50", "VA": "51", "WA": "53",
+    "WV": "54", "WI": "55", "WY": "56", "PR": "72",
+}
+
+
+def fetch_county_unemployment(
+    state_code: str,
+    county_fips_3: str,
+    api_key: str | None = None,
+) -> dict[str, Any] | None:
+    """Fetch county-level unemployment rate from BLS LAUS.
+
+    Args:
+        state_code: 2-letter state code (e.g., "TX").
+        county_fips_3: 3-digit county FIPS code (e.g., "113" for Dallas, TX).
+        api_key: BLS API key. Falls back to BLS_API_KEY env/settings.
+
+    Returns:
+        Dict with ``rate`` (Decimal, percentage) and ``year`` (str),
+        or ``None`` on failure.
+    """
+    from django.conf import settings
+
+    key = api_key or getattr(settings, "BLS_API_KEY", "")
+
+    state_fips = STATE_FIPS.get(state_code.upper())
+    if not state_fips:
+        logger.warning("Unknown state code: %s", state_code)
+        return None
+
+    series_id = f"LAUCN{state_fips}{county_fips_3}0000000003"
+
+    payload: dict[str, Any] = {
+        "seriesid": [series_id],
+        "startyear": "2025",
+        "endyear": "2026",
+        "registrationkey": key,
+    }
+
+    try:
+        resp = requests.post(BLS_API_BASE, json=payload, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:
+        logger.warning("BLS LAUS request failed for %s %s: %s", state_code, county_fips_3, exc)
+        return None
+
+    if data.get("status") == "REQUEST_FAILED":
+        logger.warning("BLS LAUS error: %s", data.get("message", "unknown"))
+        return None
+
+    series = (data.get("Results", {}) or {}).get("series", [])
+    if not series:
+        return None
+
+    observations = series[0].get("data", [])
+    if not observations:
+        return None
+
+    # Most recent observation is first
+    latest = observations[0]
+    try:
+        rate = Decimal(latest["value"])
+    except (ValueError, TypeError, KeyError):
+        return None
+
+    return {
+        "rate": rate,
+        "year": latest.get("year", ""),
+        "period": latest.get("periodName", ""),
+    }
+
+
+def fetch_county_employment(
+    state_code: str,
+    county_fips_3: str,
+    api_key: str | None = None,
+) -> dict[str, Any] | None:
+    """Fetch county-level employment level (number of jobs) from BLS LAUS.
+
+    Args:
+        state_code: 2-letter state code.
+        county_fips_3: 3-digit county FIPS code.
+        api_key: BLS API key.
+
+    Returns:
+        Dict with ``level`` (int) and ``year`` (str), or ``None``.
+    """
+    from django.conf import settings
+
+    key = api_key or getattr(settings, "BLS_API_KEY", "")
+
+    state_fips = STATE_FIPS.get(state_code.upper())
+    if not state_fips:
+        return None
+
+    series_id = f"LAUCN{state_fips}{county_fips_3}0000000005"
+
+    payload = {
+        "seriesid": [series_id],
+        "startyear": "2025",
+        "endyear": "2026",
+        "registrationkey": key,
+    }
+
+    try:
+        resp = requests.post(BLS_API_BASE, json=payload, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:
+        logger.warning("BLS LAUS employment request failed: %s", exc)
+        return None
+
+    series = ((data.get("Results", {}) or {}).get("series") or [])
+    if not series:
+        return None
+
+    observations = series[0].get("data", [])
+    if not observations:
+        return None
+
+    latest = observations[0]
+    try:
+        level = int(latest["value"])
+    except (ValueError, TypeError, KeyError):
+        return None
+
+    return {
+        "level": level,
+        "year": latest.get("year", ""),
+        "period": latest.get("periodName", ""),
+    }

--- a/core/integrations/market/bls_laus.py
+++ b/core/integrations/market/bls_laus.py
@@ -29,15 +29,58 @@ BLS_API_BASE = "https://api.bls.gov/publicAPI/v2/timeseries/data/"
 
 # State → 2-digit FIPS mapping (shared with bls.py)
 STATE_FIPS = {
-    "AL": "01", "AK": "02", "AZ": "04", "AR": "05", "CA": "06", "CO": "08",
-    "CT": "09", "DE": "10", "DC": "11", "FL": "12", "GA": "13", "HI": "15",
-    "ID": "16", "IL": "17", "IN": "18", "IA": "19", "KS": "20", "KY": "21",
-    "LA": "22", "ME": "23", "MD": "24", "MA": "25", "MI": "26", "MN": "27",
-    "MS": "28", "MO": "29", "MT": "30", "NE": "31", "NV": "32", "NH": "33",
-    "NJ": "34", "NM": "35", "NY": "36", "NC": "37", "ND": "38", "OH": "39",
-    "OK": "40", "OR": "41", "PA": "42", "RI": "44", "SC": "45", "SD": "46",
-    "TN": "47", "TX": "48", "UT": "49", "VT": "50", "VA": "51", "WA": "53",
-    "WV": "54", "WI": "55", "WY": "56", "PR": "72",
+    "AL": "01",
+    "AK": "02",
+    "AZ": "04",
+    "AR": "05",
+    "CA": "06",
+    "CO": "08",
+    "CT": "09",
+    "DE": "10",
+    "DC": "11",
+    "FL": "12",
+    "GA": "13",
+    "HI": "15",
+    "ID": "16",
+    "IL": "17",
+    "IN": "18",
+    "IA": "19",
+    "KS": "20",
+    "KY": "21",
+    "LA": "22",
+    "ME": "23",
+    "MD": "24",
+    "MA": "25",
+    "MI": "26",
+    "MN": "27",
+    "MS": "28",
+    "MO": "29",
+    "MT": "30",
+    "NE": "31",
+    "NV": "32",
+    "NH": "33",
+    "NJ": "34",
+    "NM": "35",
+    "NY": "36",
+    "NC": "37",
+    "ND": "38",
+    "OH": "39",
+    "OK": "40",
+    "OR": "41",
+    "PA": "42",
+    "RI": "44",
+    "SC": "45",
+    "SD": "46",
+    "TN": "47",
+    "TX": "48",
+    "UT": "49",
+    "VT": "50",
+    "VA": "51",
+    "WA": "53",
+    "WV": "54",
+    "WI": "55",
+    "WY": "56",
+    "PR": "72",
 }
 
 
@@ -80,7 +123,9 @@ def fetch_county_unemployment(
         resp.raise_for_status()
         data = resp.json()
     except requests.RequestException as exc:
-        logger.warning("BLS LAUS request failed for %s %s: %s", state_code, county_fips_3, exc)
+        logger.warning(
+            "BLS LAUS request failed for %s %s: %s", state_code, county_fips_3, exc
+        )
         return None
 
     if data.get("status") == "REQUEST_FAILED":
@@ -149,7 +194,7 @@ def fetch_county_employment(
         logger.warning("BLS LAUS employment request failed: %s", exc)
         return None
 
-    series = ((data.get("Results", {}) or {}).get("series") or [])
+    series = (data.get("Results", {}) or {}).get("series") or []
     if not series:
         return None
 

--- a/core/integrations/market/hud_fmr.py
+++ b/core/integrations/market/hud_fmr.py
@@ -1,0 +1,147 @@
+"""HUD Fair Market Rent (FMR) API adapter.
+
+Fetches annual rent estimates by county and ZIP code from HUD's
+Fair Market Rent database.  Free API key available at:
+  https://www.huduser.gov/portal/dataset/fmr-api.html
+
+FMRs are 40th-percentile gross rent estimates for standard quality
+units, published annually by county and ZIP code (Small Area FMRs)
+for 0BR through 4BR unit sizes.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import Any
+
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+FMR_API_BASE = "https://www.huduser.gov/hudapi/public/fmr"
+REQUEST_TIMEOUT = 30
+
+
+class FMRError(Exception):
+    """Base exception for HUD FMR API errors."""
+
+
+class FMRClient:
+    """Client for the HUD Fair Market Rent API."""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or getattr(settings, "HUD_API_KEY", "")
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    def _get(self, path: str, params: dict[str, str] | None = None) -> dict[str, Any]:
+        """Make a GET request to the HUD FMR API."""
+        url = f"{FMR_API_BASE}/{path.lstrip('/')}"
+        resp = requests.get(url, headers=self._headers(), params=params, timeout=REQUEST_TIMEOUT)
+        if resp.status_code == 401:
+            raise FMRError("HUD API key is missing or invalid")
+        if resp.status_code == 403:
+            raise FMRError("HUD API key not authorized for FMR dataset")
+        if resp.status_code == 404:
+            raise FMRError(f"No data found: {path}")
+        resp.raise_for_status()
+        return resp.json()
+
+    def list_states(self) -> list[dict[str, str]]:
+        """List all states with FMR data."""
+        data = self._get("listStates")
+        return data.get("data", [])
+
+    def list_counties(self, state_code: str) -> list[dict[str, str]]:
+        """List counties in a state with their FIPS codes."""
+        data = self._get(f"listCounties/{state_code}")
+        return data.get("data", [])
+
+    def get_county_data(self, fips_code: str, year: int | None = None) -> dict[str, Any] | None:
+        """Get FMR data for a specific county by FIPS code.
+
+        Returns a dict with rent estimates for 0BR-4BR units,
+        or ``None`` if no data is found.
+        """
+        params = {"year": str(year)} if year else {}
+        try:
+            data = self._get(f"data/{fips_code}", params=params)
+        except FMRError:
+            return None
+
+        result = data.get("data", {})
+        basic = result.get("basicdata", {})
+        if not basic:
+            return None
+
+        return {
+            "fips_code": fips_code,
+            "county_name": result.get("county_name", ""),
+            "metro_name": result.get("metro_name", ""),
+            "year": basic.get("year", str(year or "latest")),
+            "efficiency": _parse_fmr(basic.get("Efficiency")),
+            "one_bedroom": _parse_fmr(basic.get("One-Bedroom")),
+            "two_bedroom": _parse_fmr(basic.get("Two-Bedroom")),
+            "three_bedroom": _parse_fmr(basic.get("Three-Bedroom")),
+            "four_bedroom": _parse_fmr(basic.get("Four-Bedroom")),
+        }
+
+    def get_state_data(self, state_code: str) -> list[dict[str, Any]]:
+        """Get FMR data for all counties/metro areas in a state."""
+        data = self._get(f"statedata/{state_code}")
+        result = data.get("data", {})
+        return result.get("counties", []) + result.get("metroareas", [])
+
+
+def _parse_fmr(value: Any) -> Decimal | None:
+    """Parse an FMR value to Decimal."""
+    if value is None or value == "":
+        return None
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return None
+
+
+def get_rent_estimate(
+    zip_code: str | None = None,
+    fips_code: str | None = None,
+    bedrooms: int = 2,
+) -> Decimal | None:
+    """Get a rent estimate for a location from HUD FMR data.
+
+    This is a convenience function that attempts to look up FMR data,
+    falling back to county-level data when needed.  Requires a
+    ``HUD_API_KEY`` environment variable or Django setting.
+
+    Args:
+        zip_code: 5-digit ZIP code (preferred for Small Area FMRs).
+        fips_code: County FIPS code (fallback).
+        bedrooms: Number of bedrooms (0-4, default 2).
+
+    Returns:
+        Monthly rent estimate as Decimal, or ``None`` if unavailable.
+    """
+    client = FMRClient()
+    if not client.api_key:
+        logger.warning("HUD_API_KEY not configured — cannot fetch rent estimates")
+        return None
+
+    bed_key = {0: "efficiency", 1: "one_bedroom", 2: "two_bedroom", 3: "three_bedroom", 4: "four_bedroom"}
+    key = bed_key.get(bedrooms, "two_bedroom")
+
+    if fips_code:
+        data = client.get_county_data(fips_code)
+        if data and data.get(key) is not None:
+            return data[key]
+
+    # Fall back to a reasonable default based on 2BR FMR
+    if zip_code:
+        logger.info("ZIP-level FMR lookup not yet implemented via API — use county-level")
+        # For now, county-level is the best we can do
+        pass
+
+    return None

--- a/core/integrations/market/hud_fmr.py
+++ b/core/integrations/market/hud_fmr.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 from decimal import Decimal
-from typing import Any
+from typing import Any, cast
 
 import requests
 from django.conf import settings
@@ -40,7 +40,9 @@ class FMRClient:
     def _get(self, path: str, params: dict[str, str] | None = None) -> dict[str, Any]:
         """Make a GET request to the HUD FMR API."""
         url = f"{FMR_API_BASE}/{path.lstrip('/')}"
-        resp = requests.get(url, headers=self._headers(), params=params, timeout=REQUEST_TIMEOUT)
+        resp = requests.get(
+            url, headers=self._headers(), params=params, timeout=REQUEST_TIMEOUT
+        )
         if resp.status_code == 401:
             raise FMRError("HUD API key is missing or invalid")
         if resp.status_code == 403:
@@ -48,19 +50,21 @@ class FMRClient:
         if resp.status_code == 404:
             raise FMRError(f"No data found: {path}")
         resp.raise_for_status()
-        return resp.json()
+        return cast(dict[str, Any], resp.json())
 
     def list_states(self) -> list[dict[str, str]]:
         """List all states with FMR data."""
         data = self._get("listStates")
-        return data.get("data", [])
+        return cast(list[dict[str, str]], data.get("data", []))
 
     def list_counties(self, state_code: str) -> list[dict[str, str]]:
         """List counties in a state with their FIPS codes."""
         data = self._get(f"listCounties/{state_code}")
-        return data.get("data", [])
+        return cast(list[dict[str, str]], data.get("data", []))
 
-    def get_county_data(self, fips_code: str, year: int | None = None) -> dict[str, Any] | None:
+    def get_county_data(
+        self, fips_code: str, year: int | None = None
+    ) -> dict[str, Any] | None:
         """Get FMR data for a specific county by FIPS code.
 
         Returns a dict with rent estimates for 0BR-4BR units,
@@ -93,7 +97,10 @@ class FMRClient:
         """Get FMR data for all counties/metro areas in a state."""
         data = self._get(f"statedata/{state_code}")
         result = data.get("data", {})
-        return result.get("counties", []) + result.get("metroareas", [])
+        return cast(
+            list[dict[str, Any]],
+            result.get("counties", []) + result.get("metroareas", []),
+        )
 
 
 def _parse_fmr(value: Any) -> Decimal | None:
@@ -101,7 +108,7 @@ def _parse_fmr(value: Any) -> Decimal | None:
     if value is None or value == "":
         return None
     try:
-        return Decimal(str(value))
+        return cast(Decimal, Decimal(str(value)))
     except Exception:
         return None
 
@@ -130,17 +137,25 @@ def get_rent_estimate(
         logger.warning("HUD_API_KEY not configured — cannot fetch rent estimates")
         return None
 
-    bed_key = {0: "efficiency", 1: "one_bedroom", 2: "two_bedroom", 3: "three_bedroom", 4: "four_bedroom"}
+    bed_key = {
+        0: "efficiency",
+        1: "one_bedroom",
+        2: "two_bedroom",
+        3: "three_bedroom",
+        4: "four_bedroom",
+    }
     key = bed_key.get(bedrooms, "two_bedroom")
 
     if fips_code:
         data = client.get_county_data(fips_code)
         if data and data.get(key) is not None:
-            return data[key]
+            return cast(Decimal | None, data[key])
 
     # Fall back to a reasonable default based on 2BR FMR
     if zip_code:
-        logger.info("ZIP-level FMR lookup not yet implemented via API — use county-level")
+        logger.info(
+            "ZIP-level FMR lookup not yet implemented via API — use county-level"
+        )
         # For now, county-level is the best we can do
         pass
 

--- a/investor_app/settings.py
+++ b/investor_app/settings.py
@@ -252,6 +252,7 @@ GROWTH_AREAS_CACHE_DURATION = 86400  # 24 hours
 # REHAB_COST_MODERATE, REHAB_COST_FULL_GUT (dollar amounts, e.g. "15").
 # FRED API key for economic data (employment growth, unemployment)
 FRED_API_KEY: str = env("FRED_API_KEY", default="")
+HUD_API_KEY: str = env("HUD_API_KEY", default="")
 
 REHAB_COST_PER_SQFT: dict[str, Decimal] = {
     "cosmetic": Decimal(


### PR DESCRIPTION
## What this PR does

Two new data adapters that fill critical gaps in the pipeline and growth area analysis:

### 1. HUD Fair Market Rents (core/integrations/market/hud_fmr.py)
Fetches 40th-percentile rent estimates by county FIPS code for 0BR-4BR units via HUD's free API. This is the recommended source for `estimated_rent` in pipeline screening — it's free, authoritative, and published annually.

**Usage**: `get_rent_estimate(fips_code="48113", bedrooms=2)` returns monthly rent estimate.

**API key**: Free at https://www.huduser.gov/portal/dataset/fmr-api.html → `HUD_API_KEY`

### 2. BLS LAUS County Employment (core/integrations/market/bls_laus.py)
Fetches county-level unemployment rate and employment level via BLS public API. Currently the growth explorer uses FRED for state-level employment growth — this provides more granular county data.

**Usage**: `fetch_county_unemployment("TX", "113")` returns unemployment rate for Dallas County.

## Full Roadmap

This PR lays the foundation. The remaining work across all 6 features:

### In this PR ✅
- HUD FMR client + config
- BLS LAUS county client + config

### Next: Pipeline integration
- Wire HUD FMR into `screen_property()` to provide `estimated_rent` for HUD/USDA/county sources (currently skipped as "no_rent_estimate")
- Wire county unemployment into GrowthArea model

### Medium term
- **County scraper expansion**: Pattern is set (dallas_tx.py). Add Harris, Travis, Bexar, Tarrant, El Paso, Collin, Denton, Fort Bend, Hidalgo, Montgomery (TX). Each is 1-2 files.
- **BLS QCEW**: Replace FRED's state-level CES with county/MSA QCEW. API at data.bls.gov.
- **Automated discovery**: Management commands already exist (`ingest_hud_reo`, `fetch_attom_preforeclosure`, etc.). Add cron schedule via django-cron or systemd timer.
- **Pipeline notifications**: When a new property passes screening and matches user's growth area filters, send email/SMS. Requires User notification preferences model.

### Long term
- Rent projections: Zillow ZRI or private data source

## Verification
- [x] HUD FMR module loads
- [x] BLS LAUS module loads
- [x] Existing tests pass