### PR TITLE
fix: score breakdown matches actual GACS v2 weights (GA-BUG-1)

### DIFF
--- a/templates/growth_areas.html
+++ b/templates/growth_areas.html
@@ -89,9 +89,10 @@
                   <tbody>
                     <tr><td>Employment growth</td><td>{{ ga.employment_growth_rate|mul:100|floatformat:2 }}%</td><td>35%</td></tr>
                     <tr><td>Population growth</td><td>{{ ga.population_growth_rate|mul:100|floatformat:2 }}%</td><td>20%</td></tr>
-                    <tr><td>Income growth</td><td>{{ ga.median_income_growth|mul:100|floatformat:2 }}%</td><td>20%</td></tr>
-                    <tr><td>Supply constraint</td><td>{{ ga.supply_constraint_index }}</td><td>15%</td></tr>
-                    <tr><td>Housing demand</td><td>{{ ga.housing_demand_index }}</td><td>10%</td></tr>
+                    <tr><td>Income growth</td><td>{{ ga.median_income_growth|mul:100|floatformat:2 }}%</td><td>15%</td></tr>
+                    <tr><td>School quality</td><td>{{ ga.school_score|default:"—" }}</td><td>15%</td></tr>
+                    <tr><td>Supply constraint</td><td>{{ ga.supply_constraint_index }}</td><td>10%</td></tr>
+                    <tr><td>Net migration</td><td>{{ ga.net_migration_rate|default:"—" }}</td><td>5%</td></tr>
                   </tbody>
                 </table>
                 <p class="page-sub">ACS vintage: auto-detected (2024 or latest available) &middot; Data timestamp: {{ ga.data_timestamp|date:"Y-m-d" }} &middot; Confidence: {{ ga.data_confidence }}%</p>

--- a/templates/growth_explorer.html
+++ b/templates/growth_explorer.html
@@ -159,9 +159,10 @@
                   <tbody>
                     <tr><td>Employment growth</td><td>{{ r.growth_area.employment_growth_rate|mul:100|floatformat:2 }}%</td><td>35%</td></tr>
                     <tr><td>Population growth</td><td>{{ r.growth_area.population_growth_rate|mul:100|floatformat:2 }}%</td><td>20%</td></tr>
-                    <tr><td>Income growth</td><td>{{ r.growth_area.median_income_growth|mul:100|floatformat:2 }}%</td><td>20%</td></tr>
-                    <tr><td>Supply constraint</td><td>{{ r.growth_area.supply_constraint_index }}</td><td>15%</td></tr>
-                    <tr><td>Housing demand</td><td>{{ r.growth_area.housing_demand_index }}</td><td>10%</td></tr>
+                    <tr><td>Income growth</td><td>{{ r.growth_area.median_income_growth|mul:100|floatformat:2 }}%</td><td>15%</td></tr>
+                    <tr><td>School quality</td><td>{{ r.growth_area.school_score|default:"—" }}</td><td>15%</td></tr>
+                    <tr><td>Supply constraint</td><td>{{ r.growth_area.supply_constraint_index }}</td><td>10%</td></tr>
+                    <tr><td>Net migration</td><td>{{ r.growth_area.net_migration_rate|default:"—" }}</td><td>5%</td></tr>
                   </tbody>
                 </table>
                 <p class="page-sub">ACS vintage: auto-detected (2024 or latest available) &middot; Data timestamp: {{ r.growth_area.data_timestamp|date:"Y-m-d" }} &middot; Confidence: {{ r.growth_area.data_confidence }}%</p>


### PR DESCRIPTION
## What this PR does

Fixes the score breakdown tables in both growth area templates to match the actual `_compute_composite_score()` weights.

### Before (wrong)

| Component | Weight |
|---|---|
| Employment | 35% |
| Population | 20% |
| Income | **20%** |
| Supply | **15%** |
| Housing | **10%** |
| School | *(missing)* |
| Migration | *(missing)* |

### After (correct)

| Component | Weight |
|---|---|
| Employment | 35% |
| Population | 20% |
| Income | **15%** |
| School quality | **15%** *(new)* |
| Supply constraint | **10%** |
| Net migration | **5%** *(new)* |

### Files changed

- `templates/growth_areas.html` — 6 rows with correct weights + new school/migration rows
- `templates/growth_explorer.html` — same fix