### PR TITLE
fix: set metro_area to blank instead of city_name (GA-DATA-3)

### DIFF
--- a/core/management/commands/populate_growth_areas.py
+++ b/core/management/commands/populate_growth_areas.py
@@ -277,7 +277,7 @@ class Command(BaseCommand):
                     state=state_code,
                     city_name=city_name,
                     defaults={
-                        "metro_area": city_name,  # Use city name as metro area for now
+                        "metro_area": "",  # TODO: populate from Census CBSA API
                         "population": census_data.get("population_current"),
                         "population_growth_rate": pop_growth,
                         "employment_growth_rate": emp_growth,

--- a/core/tests/test_growth_explorer.py
+++ b/core/tests/test_growth_explorer.py
@@ -220,7 +220,7 @@ class TestGrowthExplorerPostSuccess:
         # DecimalField(max_digits=6, decimal_places=2) rounds to 2dp
         assert la.employment_growth_rate == Decimal("0.04")  # 0.0450 → 0.04
         assert la.housing_demand_index == 85
-        assert la.metro_area == "Los Angeles"
+        assert la.metro_area == ""  # blank until CBSA API integration
 
     @patch("core.views.discover_places_in_state")
     @patch("core.views.FREDAdapter.fetch_state_employment_growth")

--- a/core/views/__init__.py
+++ b/core/views/__init__.py
@@ -968,7 +968,7 @@ def growth_explorer(request: HttpRequest) -> HttpResponse:
             state=state,
             city_name=data["place_name"],
             defaults={
-                "metro_area": data["place_name"],
+                "metro_area": "",  # TODO: populate from Census CBSA API
                 "population": data["population"],
                 "population_growth_rate": data["pop_growth"],
                 "employment_growth_rate": safe_emp_growth,


### PR DESCRIPTION
## What this PR does

Fixes the `metro_area` field on GrowthArea — it was always set to `city_name`, making the field meaningless. Changed to blank string with TODO to populate from Census CBSA API when available.

### Changes

| File | Line | Before | After |
|---|---|---|---|
| `populate_growth_areas.py` | 280 | `"metro_area": city_name` | `"metro_area": ""` + TODO |
| `core/views/__init__.py` | 971 | `"metro_area": data["place_name"]` | `"metro_area": ""` + TODO |
| `test_growth_explorer.py` | 223 | `assert la.metro_area == "Los Angeles"` | `assert la.metro_area == ""` |

### Verification

- [x] `GrowthArea.objects.filter(metro_area=F("city_name")).count()` would return 0 for new records
- [x] 20/20 growth area tests pass