### PR TITLE
fix: add confidence column to growth area tables (GA-UX-1)

### DIFF
--- a/templates/growth_areas.html
+++ b/templates/growth_areas.html
@@ -65,6 +65,7 @@
             <th>Income Growth (5yr)</th>
             <th>Housing Demand</th>
             <th>Composite Score</th>
+            <th>Conf.</th>
             <th></th>
           </tr>
         </thead>
@@ -80,10 +81,21 @@
               <td class="col-right num">{{ ga.median_income_growth|mul:100|floatformat:2 }}%</td>
               <td class="col-right">{{ ga.housing_demand_index }}</td>
               <td class="col-right score-num num-good">{{ ga.composite_score|default_if_none:""|floatformat:2 }}</td>
+              <td>
+                {% with conf=ga.data_confidence %}
+                  {% if conf >= 80 %}
+                    <span class="chip chip-success">{{ conf }}%</span>
+                  {% elif conf >= 50 %}
+                    <span class="chip chip-warning">{{ conf }}%</span>
+                  {% else %}
+                    <span class="chip chip-danger">{{ conf }}%</span>
+                  {% endif %}
+                {% endwith %}
+              </td>
               <td><a href="{% url 'vrm_properties_list' %}?state={{ ga.state }}" class="btn">Foreclosures</a> <button class="btn" onclick="var r=document.getElementById('breakdown-{{ forloop.counter0 }}');r.hidden=!r.hidden">Score</button></td>
             </tr>
             <tr id="breakdown-{{ forloop.counter0 }}" hidden>
-              <td colspan="10">
+              <td colspan="11">
                 <table class="data-table">
                   <thead><tr><th>Component</th><th>Value</th><th>Weight</th></tr></thead>
                   <tbody>

--- a/templates/growth_explorer.html
+++ b/templates/growth_explorer.html
@@ -119,6 +119,7 @@
               <th>Housing Demand</th>
               <th>Supply Constraint</th>
               <th>Composite Score</th>
+              <th>Conf.</th>
               <th>Action</th>
             </tr>
           </thead>
@@ -147,13 +148,24 @@
               </td>
               <td class="col-right score-num num-good">{{ r.growth_area.composite_score|default_if_none:""|floatformat:2 }}</td>
               <td>
+                {% with conf=r.growth_area.data_confidence %}
+                  {% if conf >= 80 %}
+                    <span class="chip chip-success">{{ conf }}%</span>
+                  {% elif conf >= 50 %}
+                    <span class="chip chip-warning">{{ conf }}%</span>
+                  {% else %}
+                    <span class="chip chip-danger">{{ conf }}%</span>
+                  {% endif %}
+                {% endwith %}
+              </td>
+              <td>
                 <a href="{% url 'vrm_properties_list' %}?state={{ r.growth_area.state }}" class="btn">View Foreclosures</a>
                 <button type="submit" name="pipeline_city" value="{{ r.place_name }}" class="btn" title="Run property discovery pipeline for {{ r.place_name }}, {{ r.growth_area.state }}">🔍 Discover</button>
                 <button type="button" class="btn" onclick="var r=document.getElementById('ge-breakdown-{{ forloop.counter0 }}');r.hidden=!r.hidden">Score</button>
               </td>
             </tr>
             <tr id="ge-breakdown-{{ forloop.counter0 }}" hidden>
-              <td colspan="11">
+              <td colspan="12">
                 <table class="data-table">
                   <thead><tr><th>Component</th><th>Value</th><th>Weight</th></tr></thead>
                   <tbody>


### PR DESCRIPTION
## What this PR adds

A color-coded **Conf.** column to both growth area tables showing `data_confidence%`:

| Range | Color | Meaning |
|---|---|---|
| ≥ 80% | 🟢 chip-success | All components have real data |
| 50-79% | 🟡 chip-warning | Some defaults/placeholders used |
| < 50% | 🔴 chip-danger | Mostly defaulted data |

### Files changed

| File | Change |
|---|---|
| `templates/growth_areas.html` | Added Conf. header + chip cell; colspan 10→11 |
| `templates/growth_explorer.html` | Added Conf. header + chip cell; colspan 11→12 |

### CSS classes used (all existing)
- `chip`, `chip-success`, `chip-warning`, `chip-danger` — already in base.css

### Verification
- [x] 20/20 growth area tests pass
- [x] No new CSS classes
- [x] Confidence colors use existing chip variants