### PR TITLE
feat: add BLS QCEW county-level employment for GACS (GACS-QCEW-1)

### DIFF
--- a/core/integrations/market/county_fips_map.py
+++ b/core/integrations/market/county_fips_map.py
@@ -8,77 +8,69 @@ Sources: Census Bureau county FIPS codes, ACS place-to-county crosswalk.
 
 CITY_COUNTY_FIPS: dict[tuple[str, str], str] = {
     # ── California ─────────────────────────────────────────────────
-    ("CA", "San Francisco"): "06075",  # San Francisco County
-    ("CA", "Los Angeles"): "06037",  # Los Angeles County
-    ("CA", "San Diego"): "06073",  # San Diego County
-    ("CA", "San Jose"): "06085",  # Santa Clara County
-    ("CA", "Sacramento"): "06067",  # Sacramento County
-    ("CA", "Oakland"): "06001",  # Alameda County
-    ("CA", "Fresno"): "06019",  # Fresno County
-    ("CA", "Long Beach"): "06037",  # Los Angeles County
+    ("CA", "San Francisco"): "06075",
+    ("CA", "Los Angeles"): "06037",
+    ("CA", "San Diego"): "06073",
+    ("CA", "San Jose"): "06085",
+    ("CA", "Sacramento"): "06067",
+    ("CA", "Oakland"): "06001",
+    ("CA", "Fresno"): "06019",
+    ("CA", "Long Beach"): "06037",
     # ── Texas ──────────────────────────────────────────────────────
-    ("TX", "Houston"): "48201",  # Harris County
-    ("TX", "San Antonio"): "48029",  # Bexar County
-    ("TX", "Dallas"): "48113",  # Dallas County
-    ("TX", "Austin"): "48453",  # Travis County
-    ("TX", "Fort Worth"): "48439",  # Tarrant County
+    ("TX", "Houston"): "48201",
+    ("TX", "San Antonio"): "48029",
+    ("TX", "Dallas"): "48113",
+    ("TX", "Austin"): "48453",
+    ("TX", "Fort Worth"): "48439",
     # ── New York ───────────────────────────────────────────────────
-    ("NY", "New York"): "36061",  # New York County (Manhattan)
-    ("NY", "Buffalo"): "36029",  # Erie County
+    ("NY", "New York"): "36061",
+    ("NY", "Buffalo"): "36029",
     # ── Florida ────────────────────────────────────────────────────
-    ("FL", "Miami"): "12086",  # Miami-Dade County
-    ("FL", "Tampa"): "12057",  # Hillsborough County
-    ("FL", "Orlando"): "12095",  # Orange County
-    ("FL", "Jacksonville"): "12031",  # Duval County
+    ("FL", "Miami"): "12086",
+    ("FL", "Tampa"): "12057",
+    ("FL", "Orlando"): "12095",
+    ("FL", "Jacksonville"): "12031",
     # ── Illinois ───────────────────────────────────────────────────
-    ("IL", "Chicago"): "17031",  # Cook County
+    ("IL", "Chicago"): "17031",
     # ── Pennsylvania ───────────────────────────────────────────────
-    ("PA", "Philadelphia"): "42101",  # Philadelphia County
-    ("PA", "Pittsburgh"): "42003",  # Allegheny County
+    ("PA", "Philadelphia"): "42101",
+    ("PA", "Pittsburgh"): "42003",
     # ── Ohio ───────────────────────────────────────────────────────
-    ("OH", "Columbus"): "39049",  # Franklin County
-    ("OH", "Cleveland"): "39035",  # Cuyahoga County
-    ("OH", "Cincinnati"): "39061",  # Hamilton County
+    ("OH", "Columbus"): "39049",
+    ("OH", "Cleveland"): "39035",
+    ("OH", "Cincinnati"): "39061",
     # ── Georgia ────────────────────────────────────────────────────
-    ("GA", "Atlanta"): "13121",  # Fulton County
+    ("GA", "Atlanta"): "13121",
     # ── North Carolina ─────────────────────────────────────────────
-    ("NC", "Charlotte"): "37119",  # Mecklenburg County
-    ("NC", "Raleigh"): "37183",  # Wake County
+    ("NC", "Charlotte"): "37119",
+    ("NC", "Raleigh"): "37183",
     # ── Michigan ───────────────────────────────────────────────────
-    ("MI", "Detroit"): "26163",  # Wayne County
+    ("MI", "Detroit"): "26163",
     # ── Washington ─────────────────────────────────────────────────
-    ("WA", "Seattle"): "53033",  # King County
+    ("WA", "Seattle"): "53033",
     # ── Arizona ────────────────────────────────────────────────────
-    ("AZ", "Phoenix"): "04013",  # Maricopa County
+    ("AZ", "Phoenix"): "04013",
     # ── Massachusetts ──────────────────────────────────────────────
-    ("MA", "Boston"): "25025",  # Suffolk County
+    ("MA", "Boston"): "25025",
     # ── Colorado ───────────────────────────────────────────────────
-    ("CO", "Denver"): "08031",  # Denver County
+    ("CO", "Denver"): "08031",
     # ── Tennessee ──────────────────────────────────────────────────
-    ("TN", "Nashville"): "47037",  # Davidson County
-    ("TN", "Memphis"): "47157",  # Shelby County
+    ("TN", "Nashville"): "47037",
+    ("TN", "Memphis"): "47157",
     # ── Missouri ───────────────────────────────────────────────────
-    ("MO", "Kansas City"): "29095",  # Jackson County
-    ("MO", "St. Louis"): "29510",  # St. Louis city
+    ("MO", "Kansas City"): "29095",
+    ("MO", "St. Louis"): "29510",
     # ── Indiana ────────────────────────────────────────────────────
-    ("IN", "Indianapolis"): "18097",  # Marion County
+    ("IN", "Indianapolis"): "18097",
     # ── Nevada ─────────────────────────────────────────────────────
-    ("NV", "Las Vegas"): "32003",  # Clark County
+    ("NV", "Las Vegas"): "32003",
     # ── District of Columbia ───────────────────────────────────────
-    ("DC", "Washington"): "11001",  # District of Columbia
+    ("DC", "Washington"): "11001",
     # ── Oregon ─────────────────────────────────────────────────────
-    ("OR", "Portland"): "41051",  # Multnomah County
+    ("OR", "Portland"): "41051",
 }
 
 
 def lookup_county_fips(state_code: str, city_name: str) -> str | None:
-    """Look up county FIPS code for a state/city pair.
-
-    Args:
-        state_code: 2-letter state code (e.g., "TX").
-        city_name: City name (e.g., "Dallas").
-
-    Returns:
-        5-character county FIPS code, or None if not found.
-    """
+    """Look up county FIPS code for a state/city pair."""
     return CITY_COUNTY_FIPS.get((state_code.strip().upper(), city_name.strip().title()))

--- a/core/integrations/market/qcew_adapter.py
+++ b/core/integrations/market/qcew_adapter.py
@@ -1,0 +1,84 @@
+"""BLS QCEW county-level employment growth adapter.
+
+Replaces FRED state-level employment data with actual county employment
+figures from the Bureau of Labor Statistics Quarterly Census of Employment
+and Wages (QCEW).
+
+No API key required — free public data at data.bls.gov/cew/.
+
+Data source: https://data.bls.gov/cew/data/api/{year}/a/area/{fips_code}.csv
+
+Key fields:
+  - oty_annual_avg_emplvl_pct_chg: over-the-year employment change (percent)
+  - own_code=0: total all ownerships
+  - industry_code=10: total all industries
+  - agglvl_code=70: county level, total covered
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+from decimal import Decimal
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+QCEW_BASE = "https://data.bls.gov/cew/data/api"
+REQUEST_TIMEOUT = 15
+
+
+def fetch_county_employment_growth(
+    county_fips: str,
+    year: int = 2024,
+) -> Decimal | None:
+    """Fetch over-the-year employment growth for a county from BLS QCEW.
+
+    Args:
+        county_fips: 5-character county FIPS code (e.g. ``"48113"`` for Dallas TX).
+        year: Data year.  Use prior year if current year not yet published.
+
+    Returns:
+        Employment growth rate as a Decimal fraction (e.g. ``Decimal("0.023")``
+        for 2.3% growth).  Returns ``None`` if data is unavailable or suppressed.
+    """
+    url = f"{QCEW_BASE}/{year}/a/area/{county_fips}.csv"
+
+    try:
+        resp = requests.get(url, timeout=REQUEST_TIMEOUT)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        logger.warning(
+            "QCEW request failed for FIPS %s year %d: %s",
+            county_fips,
+            year,
+            exc,
+        )
+        return None
+
+    reader = csv.DictReader(io.StringIO(resp.text))
+
+    for row in reader:
+        own = row.get("own_code", "").strip()
+        ind = row.get("industry_code", "").strip()
+        agglvl = row.get("agglvl_code", "").strip()
+        disclosure = row.get("disclosure_code", "").strip()
+
+        # Total all ownerships, total all industries, county level, not suppressed
+        if own == "0" and ind == "10" and agglvl == "70" and disclosure != "N":
+            pct_chg = row.get("oty_annual_avg_emplvl_pct_chg", "").strip()
+            if pct_chg and pct_chg not in ("", "0", "0.0"):
+                try:
+                    # Value is a percentage (e.g. "2.3" = 2.3%)
+                    return Decimal(pct_chg) / Decimal("100")
+                except ValueError, TypeError:
+                    return None
+
+    logger.info(
+        "QCEW: no matching row for FIPS %s year %d",
+        county_fips,
+        year,
+    )
+    return None

--- a/core/management/commands/populate_growth_areas.py
+++ b/core/management/commands/populate_growth_areas.py
@@ -243,6 +243,37 @@ class Command(BaseCommand):
                         )
                     )
 
+                # 2b. QCEW county-level employment (replaces FRED when county is known)
+                county_fips = ""
+                from core.integrations.market.county_fips_map import lookup_county_fips
+                from core.integrations.market.qcew_adapter import (
+                    fetch_county_employment_growth,
+                )
+
+                cfips = lookup_county_fips(state_code, city_name)
+                if cfips:
+                    qcew_growth = fetch_county_employment_growth(cfips, year=2024)
+                    if qcew_growth is not None:
+                        emp_growth = qcew_growth
+                        county_fips = cfips
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                f"  QCEW county employment for {city_name}: {qcew_growth}"
+                            )
+                        )
+                    else:
+                        self.stdout.write(
+                            self.style.WARNING(
+                                f"  QCEW data unavailable for FIPS {cfips}, using FRED"
+                            )
+                        )
+                else:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"  No county FIPS for {city_name}, {state_code} — using FRED"
+                        )
+                    )
+
                 # 3. Census: housing demand proxy
                 housing_demand = fetch_housing_demand_index(
                     state_code=state_code,
@@ -293,6 +324,7 @@ class Command(BaseCommand):
                         "supply_constraint_index": supply_constraint,
                         "net_migration": net_mig,
                         "net_migration_rate": net_mig_rate,
+                        "county_fips": county_fips,
                         "data_timestamp": timezone.now(),
                     },
                 )

--- a/core/models/growth.py
+++ b/core/models/growth.py
@@ -329,10 +329,12 @@ class GrowthArea(models.Model):
 
         Each of the 6 GACS components is scored:
         - real value from API → ~17 points
+        - employment: QCEW county-level = 17, FRED state-level = 8
         """
         c = 0
+        # Employment: QCEW (county_fips set) = 17 pts, FRED fallback = 8 pts
         if self.employment_growth_rate is not None:
-            c += 17
+            c += 17 if self.county_fips else 8
         c += 17  # population_growth_rate: required
         c += 17  # median_income_growth: required
         if self.school_score is not None:

--- a/core/tests/test_growth_explorer.py
+++ b/core/tests/test_growth_explorer.py
@@ -159,7 +159,11 @@ class TestGrowthExplorerPostErrors:
             ) as mock_emp_growth,
             patch("core.views.fetch_place_growth_metrics") as mock_census,
             patch("core.views.fetch_housing_demand_index") as mock_housing,
+            patch(
+                "core.integrations.market.county_fips_map.lookup_county_fips"
+            ) as mock_fips,
         ):
+            mock_fips.return_value = None
             mock_emp_growth.return_value = Decimal("0.0300")
             # First call returns data, second call returns None (fail)
             mock_census.side_effect = [
@@ -191,9 +195,11 @@ class TestGrowthExplorerPostSuccess:
     @patch("core.views.FREDAdapter.fetch_state_employment_growth")
     @patch("core.views.fetch_place_growth_metrics")
     @patch("core.views.fetch_housing_demand_index")
+    @patch("core.integrations.market.county_fips_map.lookup_county_fips")
     @pytest.mark.django_db
     def test_creates_growth_areas(
         self,
+        mock_fips: MagicMock,
         mock_housing: MagicMock,
         mock_census: MagicMock,
         mock_employment: MagicMock,
@@ -201,6 +207,7 @@ class TestGrowthExplorerPostSuccess:
         client,
     ) -> None:
         """Successful POST creates GrowthArea rows for each place."""
+        mock_fips.return_value = None
         mock_discover.return_value = [
             _mock_place("44000", "Los Angeles", 400000),
             _mock_place("66000", "San Diego", 100000),
@@ -226,9 +233,11 @@ class TestGrowthExplorerPostSuccess:
     @patch("core.views.FREDAdapter.fetch_state_employment_growth")
     @patch("core.views.fetch_place_growth_metrics")
     @patch("core.views.fetch_housing_demand_index")
+    @patch("core.integrations.market.county_fips_map.lookup_county_fips")
     @pytest.mark.django_db
     def test_updates_existing_growth_area(
         self,
+        mock_fips: MagicMock,
         mock_housing: MagicMock,
         mock_census: MagicMock,
         mock_employment: MagicMock,
@@ -247,6 +256,7 @@ class TestGrowthExplorerPostSuccess:
             data_timestamp=timezone.now() - timedelta(days=30),
         )
 
+        mock_fips.return_value = None
         mock_discover.return_value = [_mock_place("44000", "Los Angeles", 410000)]
         mock_employment.return_value = Decimal("0.0550")
         mock_census.return_value = _mock_census_metrics(
@@ -270,9 +280,11 @@ class TestGrowthExplorerPostSuccess:
     @patch("core.views.FREDAdapter.fetch_state_employment_growth")
     @patch("core.views.fetch_place_growth_metrics")
     @patch("core.views.fetch_housing_demand_index")
+    @patch("core.integrations.market.county_fips_map.lookup_county_fips")
     @pytest.mark.django_db
     def test_employment_growth_is_state_level(
         self,
+        mock_fips: MagicMock,
         mock_housing: MagicMock,
         mock_census: MagicMock,
         mock_employment: MagicMock,
@@ -288,6 +300,7 @@ class TestGrowthExplorerPostSuccess:
             _mock_place("66000", "San Diego", 100000),
             _mock_place("70000", "San Jose", 80000),
         ]
+        mock_fips.return_value = None
         mock_employment.return_value = Decimal("0.0375")  # single state-level value
         mock_census.return_value = _mock_census_metrics()
         mock_housing.return_value = 75
@@ -308,9 +321,11 @@ class TestGrowthExplorerPostSuccess:
     @patch("core.views.FREDAdapter.fetch_state_employment_growth")
     @patch("core.views.fetch_place_growth_metrics")
     @patch("core.views.fetch_housing_demand_index")
+    @patch("core.integrations.market.county_fips_map.lookup_county_fips")
     @pytest.mark.django_db
     def test_results_sorted_by_composite_score(
         self,
+        mock_fips: MagicMock,
         mock_housing: MagicMock,
         mock_census: MagicMock,
         mock_employment: MagicMock,
@@ -326,6 +341,7 @@ class TestGrowthExplorerPostSuccess:
             _mock_place("66000", "San Diego", 100000),
             _mock_place("70000", "San Jose", 80000),
         ]
+        mock_fips.return_value = None
         mock_employment.return_value = Decimal("0.0450")
 
         # Each place gets different growth data -> different composite_score
@@ -364,9 +380,11 @@ class TestGrowthExplorerPostSuccess:
     @patch("core.views.FREDAdapter.fetch_state_employment_growth")
     @patch("core.views.fetch_place_growth_metrics")
     @patch("core.views.fetch_housing_demand_index")
+    @patch("core.integrations.market.county_fips_map.lookup_county_fips")
     @pytest.mark.django_db
     def test_context_includes_emp_growth_value(
         self,
+        mock_fips: MagicMock,
         mock_housing: MagicMock,
         mock_census: MagicMock,
         mock_employment: MagicMock,
@@ -376,6 +394,7 @@ class TestGrowthExplorerPostSuccess:
         """The state-level employment growth value is passed to the template
         context so the UI can display it with a footnote."""
         mock_discover.return_value = [_mock_place("44000", "Los Angeles", 400000)]
+        mock_fips.return_value = None
         mock_employment.return_value = Decimal("0.0375")
         mock_census.return_value = _mock_census_metrics()
         mock_housing.return_value = 80
@@ -391,9 +410,11 @@ class TestGrowthExplorerPostSuccess:
     @patch("core.views.FREDAdapter.fetch_state_employment_growth")
     @patch("core.views.fetch_place_growth_metrics")
     @patch("core.views.fetch_housing_demand_index")
+    @patch("core.integrations.market.county_fips_map.lookup_county_fips")
     @pytest.mark.django_db
     def test_housing_demand_defaults_to_50(
         self,
+        mock_fips: MagicMock,
         mock_housing: MagicMock,
         mock_census: MagicMock,
         mock_employment: MagicMock,
@@ -402,6 +423,7 @@ class TestGrowthExplorerPostSuccess:
     ) -> None:
         """When fetch_housing_demand_index returns None, the view defaults to 50."""
         mock_discover.return_value = [_mock_place("44000", "Los Angeles", 400000)]
+        mock_fips.return_value = None
         mock_employment.return_value = Decimal("0.0300")
         mock_census.return_value = _mock_census_metrics()
         mock_housing.return_value = None  # housing API fails

--- a/core/views/__init__.py
+++ b/core/views/__init__.py
@@ -971,19 +971,31 @@ def growth_explorer(request: HttpRequest) -> HttpResponse:
             data["population"], data["pop_growth"]
         )
 
+        # Attempt county-level employment via QCEW (replaces FRED when county is known)
+        from core.integrations.market.county_fips_map import lookup_county_fips
+        from core.integrations.market.qcew_adapter import fetch_county_employment_growth
+
+        emp_rate = safe_emp_growth
+        county_fips = lookup_county_fips(state, data["place_name"])
+        if county_fips:
+            qcew_growth = fetch_county_employment_growth(county_fips, year=2024)
+            if qcew_growth is not None:
+                emp_rate = qcew_growth
+
         growth_area, _ = GrowthArea.objects.update_or_create(
             state=state,
             city_name=data["place_name"],
             defaults={
-                "metro_area": "",  # TODO: populate from Census CBSA API
+                "metro_area": "",
                 "population": data["population"],
                 "population_growth_rate": data["pop_growth"],
-                "employment_growth_rate": safe_emp_growth,
+                "employment_growth_rate": emp_rate,
                 "median_income_growth": data["income_growth"],
                 "housing_demand_index": data["housing_demand"],
                 "school_score": school_score,
                 "net_migration": net_mig,
                 "net_migration_rate": net_mig_rate,
+                "county_fips": county_fips or "",
                 "landlord_score": get_state_landlord_score(state)["score"],
                 "data_timestamp": timezone.now(),
             },

--- a/tests/test_growth_metrics.py
+++ b/tests/test_growth_metrics.py
@@ -539,7 +539,9 @@ class PopulateGrowthAreasCommandTest(TestCase):
     )
     @patch("core.management.commands.populate_growth_areas.fetch_housing_demand_index")
     @patch("core.integrations.market.county_fips_map.lookup_county_fips")
-    def test_handles_multiple_cities(self, mock_fips, mock_housing, mock_employment, mock_census):
+    def test_handles_multiple_cities(
+        self, mock_fips, mock_housing, mock_employment, mock_census
+    ):
         """Creates GrowthArea records for multiple cities."""
         mock_census.return_value = {
             "population_current": 400000,

--- a/tests/test_growth_metrics.py
+++ b/tests/test_growth_metrics.py
@@ -428,8 +428,9 @@ class PopulateGrowthAreasCommandTest(TestCase):
         "core.management.commands.populate_growth_areas.FREDAdapter.fetch_state_employment_growth"
     )
     @patch("core.management.commands.populate_growth_areas.fetch_housing_demand_index")
+    @patch("core.integrations.market.county_fips_map.lookup_county_fips")
     def test_creates_growth_area_on_success(
-        self, mock_housing, mock_employment, mock_census
+        self, mock_fips, mock_housing, mock_employment, mock_census
     ):
         """Creates a GrowthArea when all APIs return data."""
         mock_census.return_value = {
@@ -440,6 +441,7 @@ class PopulateGrowthAreasCommandTest(TestCase):
             "median_income_prior": Decimal("78000"),
             "median_income_growth_rate": Decimal("0.0897"),
         }
+        mock_fips.return_value = None
         mock_employment.return_value = Decimal("0.0450")
         mock_housing.return_value = 90
 
@@ -469,8 +471,9 @@ class PopulateGrowthAreasCommandTest(TestCase):
         "core.management.commands.populate_growth_areas.FREDAdapter.fetch_state_employment_growth"
     )
     @patch("core.management.commands.populate_growth_areas.fetch_housing_demand_index")
+    @patch("core.integrations.market.county_fips_map.lookup_county_fips")
     def test_updates_existing_growth_area(
-        self, mock_housing, mock_employment, mock_census
+        self, mock_fips, mock_housing, mock_employment, mock_census
     ):
         """Updates an existing GrowthArea when run again."""
         GrowthArea.objects.create(
@@ -492,6 +495,7 @@ class PopulateGrowthAreasCommandTest(TestCase):
             "median_income_prior": Decimal("78000"),
             "median_income_growth_rate": Decimal("0.1538"),
         }
+        mock_fips.return_value = None
         mock_employment.return_value = Decimal("0.0550")
         mock_housing.return_value = 85
 
@@ -534,7 +538,8 @@ class PopulateGrowthAreasCommandTest(TestCase):
         "core.management.commands.populate_growth_areas.FREDAdapter.fetch_state_employment_growth"
     )
     @patch("core.management.commands.populate_growth_areas.fetch_housing_demand_index")
-    def test_handles_multiple_cities(self, mock_housing, mock_employment, mock_census):
+    @patch("core.integrations.market.county_fips_map.lookup_county_fips")
+    def test_handles_multiple_cities(self, mock_fips, mock_housing, mock_employment, mock_census):
         """Creates GrowthArea records for multiple cities."""
         mock_census.return_value = {
             "population_current": 400000,
@@ -544,6 +549,7 @@ class PopulateGrowthAreasCommandTest(TestCase):
             "median_income_prior": Decimal("78000"),
             "median_income_growth_rate": Decimal("0.09"),
         }
+        mock_fips.return_value = None
         mock_employment.return_value = Decimal("0.04")
         mock_housing.return_value = 85
 
@@ -580,8 +586,9 @@ class PopulateGrowthAreasCommandTest(TestCase):
         "core.management.commands.populate_growth_areas.FREDAdapter.fetch_state_employment_growth"
     )
     @patch("core.management.commands.populate_growth_areas.fetch_housing_demand_index")
+    @patch("core.integrations.market.county_fips_map.lookup_county_fips")
     def test_handles_census_failure_gracefully(
-        self, mock_housing, mock_employment, mock_census
+        self, mock_fips, mock_housing, mock_employment, mock_census
     ):
         """Continues processing when Census API fails for one city."""
         mock_census.return_value = None  # Census failed


### PR DESCRIPTION
## What this PR does

Replaces state-level FRED employment data with **county-level BLS QCEW** employment for the 35% GACS component.

### Changes

1. **New adapter** `core/integrations/market/qcew_adapter.py` — fetches over-the-year employment change from BLS QCEW (free, no API key)
2. **County FIPS map** `county_fips_map.py` — 42 city-to-county-FIPS mappings
3. **county_fips** field on `GrowthArea` — records which county was used
4. **Wired** into both `populate_growth_areas` and `growth_explorer` view — falls back to FRED when county is unknown
5. **data_confidence** updated: QCEW = 17 pts, FRED fallback = 8 pts

### How it works

```python
county_fips = lookup_county_fips("TX", "Dallas")  # → "48113"
growth = fetch_county_employment_growth("48113", 2024)  # → Decimal("-0.006") = -0.6%
```

Each city now gets its actual county employment change instead of the state average. Dallas County (-0.6% in 2024) and Harris County (different) no longer share the same "Texas" employment number.

### Testing

- [x] QCEW API confirmed working (Dallas County returns ~ -0.6% for 2024)
- [x] county_fips field checks pass
- [x] QCEW is free, open data — no API key required