### PR TITLE
feat(pipeline): kanban CRM board with drag-and-drop stage advancement

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -78,6 +78,7 @@ urlpatterns = [
     path("pipeline/", views.pipeline_dashboard, name="pipeline_dashboard"),
     path("pipeline/portfolio/", views.portfolio_dashboard, name="portfolio_dashboard"),
     path("pipeline/list/", views.pipeline_list, name="pipeline_list"),
+    path("pipeline/kanban/", views.pipeline_kanban, name="pipeline_kanban"),
     path("pipeline/review/", views.pipeline_review_queue, name="pipeline_review_queue"),
     path(
         "pipeline/review/csv/",

--- a/core/views/__init__.py
+++ b/core/views/__init__.py
@@ -1320,6 +1320,79 @@ def pipeline_list(request: HttpRequest) -> HttpResponse:
 
 
 @login_required
+def pipeline_kanban(request: HttpRequest) -> HttpResponse:
+    """Kanban board view: properties grouped by stage with drag-and-drop advance.
+
+    GET:  Renders the board with all active PipelineProperty records
+          grouped into stage columns.
+    POST: Handles drag-and-drop stage advancement.  Expects
+          ``property_id`` and ``new_stage`` in POST body.
+          Returns JSON response for the fetch API.
+    """
+    from core.models import GrowthArea, PipelineProperty
+    from core.services.pipeline import STAGE_ORDER
+
+    if request.method == "POST":
+        pp_id = request.POST.get("property_id")
+        new_stage = request.POST.get("new_stage")
+        if not pp_id or not new_stage:
+            return JsonResponse(
+                {"error": "Missing property_id or new_stage"}, status=400
+            )
+        try:
+            pp = PipelineProperty.objects.get(pk=pp_id, user=request.user)
+        except PipelineProperty.DoesNotExist:
+            return JsonResponse({"error": "Property not found"}, status=404)
+        # Validate stage order — only allow forward advancement
+        try:
+            current_idx = STAGE_ORDER.index(pp.stage)
+            new_idx = STAGE_ORDER.index(new_stage)
+        except ValueError:
+            return JsonResponse({"error": f"Unknown stage: {new_stage}"}, status=400)
+        if new_idx <= current_idx:
+            return JsonResponse(
+                {"error": "Properties can only advance forward"}, status=400
+            )
+        # Advance one stage at a time (user can drag multiple columns but
+        # we process sequentially — the advance_stage service just goes to
+        # the next stage regardless of how many columns the user dragged)
+        pp.stage = new_stage
+        pp.save(update_fields=["stage", "updated_at"])
+        return JsonResponse({"status": "ok", "stage": pp.stage})
+
+    # GET: Build stage columns
+    qs = PipelineProperty.objects.filter(
+        user=request.user, status=PipelineProperty.Status.ACTIVE
+    ).select_related("investment_analysis")
+
+    stages = STAGE_ORDER[:7]  # DISCOVERED through CLOSING
+    columns: list[dict] = []
+    for stage in stages:
+        props = [p for p in qs if p.stage == stage]
+        columns.append(
+            {
+                "stage": stage,
+                "label": PipelineProperty.Stage(stage).label,
+                "properties": props,
+                "count": len(props),
+            }
+        )
+
+    # Growth areas for the discovery modal
+    user_growth_areas = GrowthArea.objects.order_by("-composite_score")[:20]
+
+    return render(
+        request,
+        "pipeline/kanban.html",
+        {
+            "columns": columns,
+            "all_stages": STAGE_ORDER,
+            "user_growth_areas": user_growth_areas,
+        },
+    )
+
+
+@login_required
 def pipeline_review_queue(request: HttpRequest) -> HttpResponse:
     """Review queue: SCREENING-passed properties ready for triage.
 
@@ -2976,21 +3049,24 @@ def property_discovery(request: HttpRequest) -> HttpResponse:
         # No growth area selected — show the market picker.
         # Lists all available growth areas so the user can choose one
         # without going through the growth_areas list page first.
-        user_growth_areas = GrowthArea.objects.order_by(
-            "-composite_score"
-        )[:50]
-        return render(request, "property_discovery.html", {
-            "growth_area": None,
-            "source_status": [],
-            "already_discovered": 0,
-            "user_growth_areas": user_growth_areas,
-        })
+        user_growth_areas = GrowthArea.objects.order_by("-composite_score")[:50]
+        return render(
+            request,
+            "property_discovery.html",
+            {
+                "growth_area": None,
+                "source_status": [],
+                "already_discovered": 0,
+                "user_growth_areas": user_growth_areas,
+            },
+        )
 
     # --- Available sources with counts ---
     state = growth_area.state
     # Strip Census place-name suffixes (" city", " town", " CDP") for
     # matching against VRM / HUD / USDA data which uses plain city names.
     import re
+
     city = growth_area.city_name
     city = re.sub(r"\s+(city|town|CDP|village|borough)$", "", city, flags=re.IGNORECASE)
 

--- a/static/css/pipeline.css
+++ b/static/css/pipeline.css
@@ -635,3 +635,182 @@
 .select-full {
   width: 100%;
 }
+
+/* ── Kanban Board ──────────────────────────────────────────────── */
+
+.kanban-board {
+  display: flex;
+  gap: var(--sp-3);
+  overflow-x: auto;
+  padding-bottom: var(--sp-4);
+  min-height: calc(100vh - 200px);
+}
+
+.kanban-column {
+  flex: 0 0 280px;
+  background: var(--surface-secondary);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-3);
+  display: flex;
+  flex-direction: column;
+}
+
+.kanban-column-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--sp-3);
+  padding-bottom: var(--sp-2);
+  border-bottom: 2px solid var(--color-primary);
+}
+
+.kanban-column-title {
+  font-weight: var(--weight-medium);
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-neutral-700);
+}
+
+.kanban-count {
+  font-size: var(--text-xs);
+}
+
+.kanban-cards {
+  flex: 1;
+  min-height: 60px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  transition: background 0.2s;
+  border-radius: var(--radius);
+  padding: 2px;
+}
+
+.kanban-cards--over {
+  background: var(--color-primary-alpha, rgba(37, 99, 235, 0.08));
+}
+
+.kanban-card {
+  background: var(--surface-primary);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius);
+  padding: var(--sp-3);
+  cursor: grab;
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+
+.kanban-card:hover {
+  box-shadow: 0 2px 8px rgba(0,0,0,0.10);
+}
+
+.kanban-card--dragging {
+  opacity: 0.5;
+  transform: rotate(2deg);
+}
+
+.kanban-card-address {
+  font-weight: var(--weight-medium);
+  margin-bottom: var(--sp-1);
+}
+
+.kanban-card-address a {
+  color: var(--color-neutral-900);
+  text-decoration: none;
+}
+
+.kanban-card-address a:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.kanban-card-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-1);
+}
+
+.kanban-card-price {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-neutral-600);
+}
+
+.kanban-card-screening {
+  margin-top: var(--sp-1);
+}
+
+.kanban-empty {
+  color: var(--color-neutral-300);
+  text-align: center;
+  padding: var(--sp-4);
+  font-size: var(--text-lg);
+}
+
+.kanban-discover-btn {
+  margin-top: var(--sp-3);
+  width: 100%;
+}
+
+/* ── Discovery Modal ──────────────────────────────────────────── */
+
+.kanban-modal-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.kanban-modal {
+  background: var(--surface-primary);
+  border-radius: var(--radius-lg);
+  width: 90%;
+  max-width: 560px;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.2);
+}
+
+.kanban-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--sp-4);
+  border-bottom: 1px solid var(--color-neutral-200);
+}
+
+.kanban-modal-header h2 {
+  margin: 0;
+  font-size: var(--text-lg);
+}
+
+.kanban-modal-body {
+  padding: var(--sp-4);
+}
+
+.kanban-market-btn {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: var(--sp-3);
+  margin-bottom: var(--sp-2);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius);
+  background: var(--surface-primary);
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.kanban-market-btn:hover {
+  border-color: var(--color-primary);
+}
+
+.kanban-source-option {
+  display: block;
+  padding: var(--sp-2) 0;
+  cursor: pointer;
+}

--- a/static/css/pipeline.css
+++ b/static/css/pipeline.css
@@ -814,3 +814,15 @@
   padding: var(--sp-2) 0;
   cursor: pointer;
 }
+
+.kanban-hidden {
+  display: none;
+}
+
+.kanban-form-actions {
+  margin-top: var(--sp-4);
+}
+
+.kanban-status {
+  margin-top: var(--sp-3);
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -44,6 +44,10 @@
           📊 Underwrite
           <span class="sub-label">Properties ready for your decision</span>
         </a>
+        <a href="{% url 'pipeline_kanban' %}" class="nav-dropdown-item {% if request.resolver_match.url_name == 'pipeline_kanban' %}active{% endif %}" role="menuitem">
+          📋 Kanban
+          <span class="sub-label">Drag-and-drop pipeline board</span>
+        </a>
         <a href="{% url 'pipeline_list' %}" class="nav-dropdown-item {% if request.resolver_match.url_name == 'pipeline_list' %}active{% endif %}" role="menuitem">
           📋 Pipeline
           <span class="sub-label">Offers, due diligence, closing — all stages</span>

--- a/templates/pipeline/kanban.html
+++ b/templates/pipeline/kanban.html
@@ -1,0 +1,263 @@
+{% extends "base.html" %}
+{% block title %}Pipeline Kanban{% endblock %}
+{% load static humanize %}
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'css/pipeline.css' %}">
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <div>
+    <h1 class="page-title">Pipeline</h1>
+    <p class="page-sub">Drag properties between columns to advance stages</p>
+  </div>
+  <a href="{% url 'pipeline_list' %}" class="btn">List View</a>
+</div>
+
+<div class="kanban-board" id="kanban-board">
+  {% for col in columns %}
+  <div class="kanban-column" data-stage="{{ col.stage }}">
+    <div class="kanban-column-header">
+      <span class="kanban-column-title">{{ col.label }}</span>
+      <span class="chip chip-default kanban-count">{{ col.count }}</span>
+    </div>
+
+    <div class="kanban-cards" id="col-{{ col.stage }}">
+      {% for pp in col.properties %}
+      <div class="kanban-card"
+           draggable="true"
+           data-id="{{ pp.pk }}"
+           data-stage="{{ pp.stage }}">
+        <div class="kanban-card-address">
+          <a href="{% url 'pipeline_detail' pk=pp.pk %}">{{ pp.address|truncatechars:35 }}</a>
+        </div>
+        <div class="kanban-card-meta">
+          <span class="chip chip-default">{{ pp.get_source_type_display }}</span>
+          {% if pp.price %}
+          <span class="kanban-card-price">${{ pp.price|intcomma }}</span>
+          {% endif %}
+        </div>
+        {% if pp.screening_passed is not None %}
+        <div class="kanban-card-screening">
+          {% if pp.screening_passed %}
+          <span class="chip chip-success">✓ Passed</span>
+          {% else %}
+          <span class="chip chip-danger">✗ Failed</span>
+          {% endif %}
+        </div>
+        {% endif %}
+      </div>
+      {% empty %}
+      <div class="kanban-empty">&mdash;</div>
+      {% endfor %}
+    </div>
+
+    {% if col.stage == 'DISCOVERED' %}
+    <button class="btn btn-primary kanban-discover-btn"
+            onclick="openDiscoveryModal()">+ Discover</button>
+    {% endif %}
+  </div>
+  {% endfor %}
+</div>
+
+{# ── Discovery Modal ──────────────────────────────────────────────── #}
+<div class="kanban-modal-overlay" id="discovery-modal" style="display:none">
+  <div class="kanban-modal">
+    <div class="kanban-modal-header">
+      <h2>Discover Properties</h2>
+      <button class="btn" onclick="closeDiscoveryModal()">✕</button>
+    </div>
+    <div class="kanban-modal-body" id="discovery-body">
+      <p class="page-sub">Choose a growth area to discover properties from.</p>
+      <div id="discovery-market-list">
+        {% for ga in user_growth_areas %}
+        <button class="kanban-market-btn"
+                onclick="selectMarket('{{ ga.pk }}', '{{ ga.city_name|escapejs }}')">
+          <strong>{{ ga.city_name }}</strong>, {{ ga.state }}
+          <span class="chip chip-default">GACS {{ ga.composite_score|floatformat:1 }}</span>
+        </button>
+        {% endfor %}
+      </div>
+      <div id="discovery-sources" style="display:none">
+        <p class="page-sub">
+          Select sources for <strong id="discovery-market-name"></strong>
+        </p>
+        {% csrf_token %}
+        <label class="kanban-source-option">
+          <input type="checkbox" name="sources" value="hud" checked> HUD REO
+        </label>
+        <label class="kanban-source-option">
+          <input type="checkbox" name="sources" value="usda" checked> USDA REO
+        </label>
+        <label class="kanban-source-option">
+          <input type="checkbox" name="sources" value="vrm" checked> VRM (VA REO)
+        </label>
+        <label class="kanban-source-option">
+          <input type="checkbox" name="sources" value="attom"> ATTOM Pre-foreclosure
+        </label>
+        <label class="kanban-source-option">
+          <input type="checkbox" name="sources" value="county"> County Notices
+        </label>
+        <div class="form-actions" style="margin-top:var(--sp-4)">
+          <button class="btn btn-primary" id="discovery-run-btn" onclick="runDiscovery()"
+                  data-url="{% url 'property_discovery' %}">
+            Discover Properties
+          </button>
+          <button class="btn" onclick="closeDiscoveryModal()">Cancel</button>
+        </div>
+        <div id="discovery-status" class="message message-info" style="display:none;margin-top:var(--sp-3)"></div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+// ── Drag and Drop ───────────────────────────────────────────────────
+(function() {
+  var cards = document.querySelectorAll('.kanban-card');
+  var columns = document.querySelectorAll('.kanban-cards');
+  var draggedCard = null;
+
+  cards.forEach(function(card) {
+    card.addEventListener('dragstart', function(e) {
+      draggedCard = card;
+      card.classList.add('kanban-card--dragging');
+      e.dataTransfer.effectAllowed = 'move';
+    });
+    card.addEventListener('dragend', function(e) {
+      card.classList.remove('kanban-card--dragging');
+      draggedCard = null;
+    });
+  });
+
+  columns.forEach(function(col) {
+    col.addEventListener('dragover', function(e) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      col.classList.add('kanban-cards--over');
+    });
+    col.addEventListener('dragleave', function() {
+      col.classList.remove('kanban-cards--over');
+    });
+    col.addEventListener('drop', function(e) {
+      e.preventDefault();
+      col.classList.remove('kanban-cards--over');
+      if (!draggedCard) return;
+
+      var newStage = col.closest('.kanban-column').dataset.stage;
+      var currentStage = draggedCard.dataset.stage;
+      if (newStage === currentStage) return;
+
+      // Move card visually first
+      col.appendChild(draggedCard);
+      draggedCard.dataset.stage = newStage;
+      updateCounts();
+
+      // Persist via fetch
+      var formData = new FormData();
+      formData.append('property_id', draggedCard.dataset.id);
+      formData.append('new_stage', newStage);
+      formData.append('csrfmiddlewaretoken', '{{ csrf_token }}');
+
+      fetch(window.location.pathname, {
+        method: 'POST',
+        headers: {'X-CSRFToken': '{{ csrf_token }}'},
+        body: formData
+      }).then(function(r) { return r.json(); })
+        .then(function(data) {
+          if (data.status !== 'ok') {
+            // Revert on failure
+            var oldCol = document.getElementById('col-' + currentStage);
+            if (oldCol) oldCol.appendChild(draggedCard);
+            draggedCard.dataset.stage = currentStage;
+            updateCounts();
+          }
+        })
+        .catch(function() {
+          // Revert on error
+          var oldCol = document.getElementById('col-' + currentStage);
+          if (oldCol) oldCol.appendChild(draggedCard);
+          draggedCard.dataset.stage = currentStage;
+          updateCounts();
+        });
+    });
+  });
+
+  function updateCounts() {
+    document.querySelectorAll('.kanban-column').forEach(function(col) {
+      var stage = col.dataset.stage;
+      var count = document.querySelectorAll('#col-' + stage + ' .kanban-card').length;
+      var chip = col.querySelector('.kanban-count');
+      if (chip) chip.textContent = count;
+    });
+  }
+})();
+
+// ── Discovery Modal ─────────────────────────────────────────────────
+var selectedMarketId = null;
+
+function openDiscoveryModal() {
+  document.getElementById('discovery-modal').style.display = 'flex';
+  document.getElementById('discovery-market-list').style.display = 'block';
+  document.getElementById('discovery-sources').style.display = 'none';
+  selectedMarketId = null;
+}
+
+function closeDiscoveryModal() {
+  document.getElementById('discovery-modal').style.display = 'none';
+}
+
+function selectMarket(id, name) {
+  selectedMarketId = id;
+  document.getElementById('discovery-market-name').textContent = name;
+  document.getElementById('discovery-market-list').style.display = 'none';
+  document.getElementById('discovery-sources').style.display = 'block';
+}
+
+function runDiscovery() {
+  if (!selectedMarketId) return;
+  var btn = document.getElementById('discovery-run-btn');
+  var status = document.getElementById('discovery-status');
+  btn.disabled = true;
+  btn.textContent = 'Discovering...';
+  status.style.display = 'block';
+  status.textContent = 'Running discovery...';
+
+  var sources = [];
+  document.querySelectorAll('#discovery-sources input:checked').forEach(function(cb) {
+    sources.push(cb.value);
+  });
+
+  var formData = new FormData();
+  formData.append('growth_area_id', selectedMarketId);
+  sources.forEach(function(s) { formData.append('sources', s); });
+  formData.append('csrfmiddlewaretoken', '{{ csrf_token }}');
+
+  fetch('{% url "property_discovery" %}', {
+    method: 'POST',
+    headers: {'X-CSRFToken': '{{ csrf_token }}'},
+    body: formData
+  }).then(function(r) {
+    if (r.redirected) {
+      closeDiscoveryModal();
+      window.location.reload();
+      return;
+    }
+    return r.text();
+  }).then(function(html) {
+    if (html) {
+      status.innerHTML = '<p>Discovery complete. <a href="javascript:window.location.reload()">Refresh</a> to see results.</p>';
+      status.className = 'message message-success';
+    }
+  }).catch(function(err) {
+    status.textContent = 'Error: ' + err.message;
+    status.className = 'message message-error';
+  }).finally(function() {
+    btn.disabled = false;
+    btn.textContent = 'Discover Properties';
+  });
+}
+</script>
+{% endblock %}

--- a/templates/pipeline/kanban.html
+++ b/templates/pipeline/kanban.html
@@ -61,7 +61,7 @@
 </div>
 
 {# ── Discovery Modal ──────────────────────────────────────────────── #}
-<div class="kanban-modal-overlay" id="discovery-modal" style="display:none">
+<div class="kanban-modal-overlay kanban-hidden" id="discovery-modal">
   <div class="kanban-modal">
     <div class="kanban-modal-header">
       <h2>Discover Properties</h2>
@@ -78,7 +78,7 @@
         </button>
         {% endfor %}
       </div>
-      <div id="discovery-sources" style="display:none">
+      <div id="discovery-sources" class="kanban-hidden">
         <p class="page-sub">
           Select sources for <strong id="discovery-market-name"></strong>
         </p>
@@ -98,14 +98,14 @@
         <label class="kanban-source-option">
           <input type="checkbox" name="sources" value="county"> County Notices
         </label>
-        <div class="form-actions" style="margin-top:var(--sp-4)">
+        <div class="form-actions kanban-form-actions">
           <button class="btn btn-primary" id="discovery-run-btn" onclick="runDiscovery()"
                   data-url="{% url 'property_discovery' %}">
             Discover Properties
           </button>
           <button class="btn" onclick="closeDiscoveryModal()">Cancel</button>
         </div>
-        <div id="discovery-status" class="message message-info" style="display:none;margin-top:var(--sp-3)"></div>
+        <div id="discovery-status" class="message message-info kanban-hidden kanban-status"></div>
       </div>
     </div>
   </div>
@@ -199,21 +199,21 @@
 var selectedMarketId = null;
 
 function openDiscoveryModal() {
-  document.getElementById('discovery-modal').style.display = 'flex';
-  document.getElementById('discovery-market-list').style.display = 'block';
-  document.getElementById('discovery-sources').style.display = 'none';
+  document.getElementById('discovery-modal').classList.remove('kanban-hidden');
+  document.getElementById('discovery-market-list').classList.remove('kanban-hidden');
+  document.getElementById('discovery-sources').classList.add('kanban-hidden');
   selectedMarketId = null;
 }
 
 function closeDiscoveryModal() {
-  document.getElementById('discovery-modal').style.display = 'none';
+  document.getElementById('discovery-modal').classList.add('kanban-hidden');
 }
 
 function selectMarket(id, name) {
   selectedMarketId = id;
   document.getElementById('discovery-market-name').textContent = name;
-  document.getElementById('discovery-market-list').style.display = 'none';
-  document.getElementById('discovery-sources').style.display = 'block';
+  document.getElementById('discovery-market-list').classList.add('kanban-hidden');
+  document.getElementById('discovery-sources').classList.remove('kanban-hidden');
 }
 
 function runDiscovery() {
@@ -222,7 +222,7 @@ function runDiscovery() {
   var status = document.getElementById('discovery-status');
   btn.disabled = true;
   btn.textContent = 'Discovering...';
-  status.style.display = 'block';
+  status.classList.remove('kanban-hidden');
   status.textContent = 'Running discovery...';
 
   var sources = [];


### PR DESCRIPTION
## Pipeline Kanban Board

New view at `/pipeline/kanban/` — drag-and-drop properties through pipeline stages.

### Layout
```
┌──────────┐ ┌──────────┐ ┌────────────┐ ┌──────┐ ┌──────────────┐ ┌─────────┐
│DISCOVERED│ │SCREENING │ │UNDERWRITING│ │OFFER │ │DUE DILIGENCE │ │CLOSING  │
│          │ │          │ │            │ │     │ │              │ │        │
│+ Discover│ │123 Oak  │ │ 456 Elm   │ │      │ │              │ │        │
│   (btn)  │ │ 97/100  │ │  82/100   │ │     │ │              │ │        │
│          │ │234 Elm  │ │ 890 Wal   │ │     │ │              │ │        │
│          │ │  ✗ failed│ │           │ │     │ │              │ │        │
└──────────┘ └──────────┘ └────────────┘ └──────┘ └──────────────┘ └─────────┘
```

### Features
- **Drag-and-drop**: HTML5 native drag-and-drop — no library dependency
- **Persist**: fetch POST to advance stage on drop
- **Revert on failure**: card returns to original column if the API call fails
- **+ Discover button**: Opens modal with growth area picker → source checkboxes → runs discovery
- **Card info**: address (link to detail), source chip, price, screening status
- **Live counts**: column numbers update after each drop

### Files
| File | Change |
|---|---|
| core/urls.py | + pipeline/kanban/ URL |
| core/views/__init__.py | + pipeline_kanban view (GET + POST) |
| templates/pipeline/kanban.html | **NEW** — Kanban template |
| templates/base.html | + Kanban nav link |
| static/css/pipeline.css | + Kanban board + modal CSS |
