### PR TITLE
feat(screening): range sliders for screening criteria; update Kanban spec

### DIFF
--- a/core/views/__init__.py
+++ b/core/views/__init__.py
@@ -2976,21 +2976,24 @@ def property_discovery(request: HttpRequest) -> HttpResponse:
         # No growth area selected — show the market picker.
         # Lists all available growth areas so the user can choose one
         # without going through the growth_areas list page first.
-        user_growth_areas = GrowthArea.objects.order_by(
-            "-composite_score"
-        )[:50]
-        return render(request, "property_discovery.html", {
-            "growth_area": None,
-            "source_status": [],
-            "already_discovered": 0,
-            "user_growth_areas": user_growth_areas,
-        })
+        user_growth_areas = GrowthArea.objects.order_by("-composite_score")[:50]
+        return render(
+            request,
+            "property_discovery.html",
+            {
+                "growth_area": None,
+                "source_status": [],
+                "already_discovered": 0,
+                "user_growth_areas": user_growth_areas,
+            },
+        )
 
     # --- Available sources with counts ---
     state = growth_area.state
     # Strip Census place-name suffixes (" city", " town", " CDP") for
     # matching against VRM / HUD / USDA data which uses plain city names.
     import re
+
     city = growth_area.city_name
     city = re.sub(r"\s+(city|town|CDP|village|borough)$", "", city, flags=re.IGNORECASE)
 

--- a/specification.md
+++ b/specification.md
@@ -401,7 +401,7 @@ section without pre-building Phase 3.
 
 ## 8. Navigation Structure
 
-### Confirmed top-level nav (paruff 2026-07-07):
+### Confirmed top-level nav (paruff 2026-07-07, revised 2026-07-12):
 
 ```
 Growth Areas | Purchase Pipeline | Portfolio | Leasing Pipeline
@@ -414,11 +414,12 @@ Growth Areas | Purchase Pipeline | Portfolio | Leasing Pipeline
 - Target Markets (/growth/) [ranked list]
 
 **Purchase Pipeline**
-- My Pipeline (/pipeline/) [kanban/list of all PipelineProperty]
-- Add Property (/pipeline/add/)
-- Screening Criteria (/pipeline/screening/settings/)
-- VRM Foreclosures (/vrm/) [existing — discovery source]
-- All Foreclosures (/foreclosures/) [existing ForeclosureProperty]
+- 🔍 Discover   (/discovery/) — market picker → source checkboxes → screener
+- ✅ Screen     (/pipeline/screener/) — screening pass/fail results
+- 📊 Underwrite (/pipeline/review/) — properties ready for decision
+- 📋 Kanban     (/pipeline/kanban/) — drag-and-drop pipeline board
+- 📋 Pipeline   (/pipeline/list/) — list view (all stages)
+- ⚙️ Criteria   (/pipeline/screening/settings/) — sliders + thresholds
 
 **Portfolio**
 - Dashboard (/portfolio/) [existing]
@@ -427,6 +428,7 @@ Growth Areas | Purchase Pipeline | Portfolio | Leasing Pipeline
 
 **Leasing Pipeline**
 - Active Listings (/leasing/)
+- Leasing Kanban (/leasing/kanban/) — drag-and-drop leasing board
 - Add Listing (/leasing/add/)
 
 ### Previous nav (to be replaced):
@@ -462,10 +464,77 @@ No business logic in models, views, or management commands.
 - AC10: Nav reflects the four top-level sections with correct submenus
 - AC11: All new models use Decimal for currency (never float)
 - AC12: All migrations reviewed and approved by paruff before running
+- AC-PK1: Pipeline Kanban loads with all 7 stage columns, drag-and-drop functional
+- AC-PK2: Discovery modal opens from Kanban's "+ Discover" button, shows growth area picker
+- AC-PK3: Sliders render and show live value updates on drag
+- AC-PK4: Screening criteria save updates and re-screens properties
+- AC-LK1: Leasing Kanban board renders with leasing stage columns
+- AC-LK2: Leasing Pipeline cards show asking rent, days-on-market badge
 
 ---
 
-## 11. What Is Explicitly NOT In This Spec
+## 12. Kanban CRM Board (2026-07-12)
+
+### 12.1 Purpose
+
+A visual drag-and-drop board replacing the list view as the primary
+pipeline interaction surface. PipelineProperty cards move through
+acquisition stages as columns.
+
+### 12.2 Columns
+
+```
+DISCOVERED → SCREENING → UNDERWRITING → OFFER → DUE_DILIGENCE → CLOSING
+```
+
+The DISCOVERED column has a "+ Discover" button that opens a modal
+to source new properties from a growth area.
+
+### 12.3 Card Display
+
+Each card shows: address (truncated, links to detail), source badge,
+price, screening pass/fail chip.
+
+### 12.4 Drag-and-Drop
+
+HTML5 drag-and-drop. Dropping on a later column calls the
+`pipeline_kanban` POST endpoint. Only forward advancement allowed.
+API failure reverts card to original column.
+
+---
+
+## 13. Screening Sliders (2026-07-12)
+
+Range sliders replace number inputs for visual threshold adjustment:
+
+| Slider | Range | Default |
+|---|---|---|
+| Min price | $0–$2,000,000 | $0 |
+| Max price | $0–$2,000,000 | $0 |
+| Min gross yield | 0–20% | 7% |
+| Max PTR | 0–50 | 15 |
+| Min bedrooms | 1–10 | 1 |
+| Min GACS | 0–100 | 0 |
+
+Each slider shows current value in a label that updates live on drag.
+
+---
+
+## 14. Leasing Pipeline Kanban
+
+### 14.1 Purpose
+
+Same drag-and-drop applied to leasing: LISTING → SHOWING →
+APPLICATION → SCREENING → APPROVED → LEASE_SIGNED → MOVE_IN → STABILIZED
+
+### 14.2 Card Display
+
+Each card shows property address, asking rent, days-on-market badge,
+applicant info (at APPLICATION+ stages).
+
+---
+
+## 11 (revised). What Is Explicitly NOT In This Spec
 
 - Automated property discovery or scraping
 - MLS / IDX integration

--- a/static/css/pipeline.css
+++ b/static/css/pipeline.css
@@ -635,3 +635,38 @@
 .select-full {
   width: 100%;
 }
+
+/* ── Range Sliders ──────────────────────────────────────────── */
+
+.slider-input {
+  width: 100%;
+  height: 6px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--color-neutral-200);
+  border-radius: 3px;
+  outline: none;
+  margin: var(--sp-3) 0;
+}
+
+.slider-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  cursor: pointer;
+  border: 2px solid white;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+}
+
+.slider-input::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  cursor: pointer;
+  border: 2px solid white;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+}

--- a/templates/pipeline/screening_settings.html
+++ b/templates/pipeline/screening_settings.html
@@ -1,158 +1,140 @@
 {% extends "base.html" %}
+{% load static humanize %}
 
-{% block title %}Screening Settings — prei{% endblock %}
+{% block title %}Screening Criteria — PREI{% endblock %}
+{% load static %}
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'css/pipeline.css' %}">
+{% endblock %}
 
 {% block content %}
-<div class="pipeline-page">
-
-  <div class="pipeline-detail-header">
-    <div>
-      <a href="{% url 'pipeline_list' %}" class="back-link">&larr; Back to Pipeline</a>
-      <h1>Screening Criteria</h1>
-    </div>
+<div class="page-header">
+  <div>
+    <h1 class="page-title">Screening Criteria</h1>
+    <p class="page-sub">Drag sliders to set thresholds. Properties outside these bounds are filtered or scored lower.</p>
   </div>
-
-  {# Top note #}
-  <div class="form-note">
-    These criteria are applied automatically when you add a property to your pipeline.
-  </div>
-
-  <form method="post">
-    {% csrf_token %}
-
-    <div class="pipeline-detail-body">
-
-      {# Price range #}
-      <div class="pipeline-detail-section">
-        <h2>Price Range</h2>
-        <p class="help-text">Filter by purchase price range.</p>
-        <div class="form-row">
-          <div class="form-field-group">
-            <label class="field-label">Min Price ($)</label>
-            <input type="number" name="min_price" step="0.01" min="0"
-                   value="{{ criteria.min_price|default:'' }}" class="field-input input-lg">
-          </div>
-          <div class="form-field-group">
-            <label class="field-label">Max Price ($)</label>
-            <input type="number" name="max_price" step="0.01" min="0"
-                   value="{{ criteria.max_price|default:'' }}" class="field-input input-lg">
-          </div>
-        </div>
-      </div>
-
-      {# Yield and ratio #}
-      <div class="pipeline-detail-section">
-        <h2>Yield &amp; Ratio</h2>
-        <div class="form-note-inline">
-          Yield screening requires a rent estimate. Properties without rent estimates will have yield criteria skipped. Currently, only VRM properties have rent estimates.
-        </div>
-        <div class="form-row">
-          <div class="form-field-group">
-            <label class="field-label">Min Gross Yield (%)</label>
-            <input type="number" name="min_gross_yield_pct" step="0.01" min="0"
-                   value="{{ criteria.min_gross_yield_pct|default:'' }}" class="field-input input-md">
-            <span class="help-text">Annual rent / price. Only VRM properties with rent.</span>
-          </div>
-          <div class="form-field-group">
-            <label class="field-label">Max P/R Ratio</label>
-            <input type="number" name="max_price_to_rent_ratio" step="0.1" min="0"
-                   value="{{ criteria.max_price_to_rent_ratio|default:'' }}" class="field-input input-md">
-            <span class="help-text">Lower = better cashflow. Only VRM properties.</span>
-          </div>
-        </div>
-      </div>
-
-      {# Beds, sqft, year built #}
-      <div class="pipeline-detail-section">
-        <h2>Size &amp; Age</h2>
-        <div class="form-row">
-          <div class="form-field-group">
-            <label class="field-label">Min Beds</label>
-            <input type="number" name="min_beds" min="0"
-                   value="{{ criteria.min_beds }}" class="field-input input-xs">
-          </div>
-          <div class="form-field-group">
-            <label class="field-label">Max Beds</label>
-            <input type="number" name="max_beds" min="0"
-                   value="{{ criteria.max_beds|default:'' }}" class="field-input input-xs">
-          </div>
-          <div class="form-field-group">
-            <label class="field-label">Min Sq Ft</label>
-            <input type="number" name="min_sqft" min="0"
-                   value="{{ criteria.min_sqft|default:'' }}" class="field-input input-sm">
-          </div>
-          <div class="form-field-group">
-            <label class="field-label">Max Year Built</label>
-            <input type="number" name="max_year_built" min="1900" max="2030"
-                   value="{{ criteria.max_year_built|default:'' }}" class="field-input input-sm">
-            <span class="help-text">Exclude older properties.</span>
-          </div>
-        </div>
-      </div>
-
-      {# Property types #}
-      <div class="pipeline-detail-section">
-        <h2>Property Types</h2>
-        <p class="help-text">Allowed property types (leave all unchecked to allow all).</p>
-        <div class="form-checkbox-grid">
-          {% for pt in property_type_choices %}
-          <label class="checkbox-label">
-            <input type="checkbox" name="allowed_property_types" value="{{ pt }}"
-                   {% if pt in criteria.allowed_property_types or not criteria.allowed_property_types %}checked{% endif %}>
-            {{ pt|title }}
-          </label>
-          {% endfor %}
-        </div>
-      </div>
-
-      {# States #}
-      <div class="pipeline-detail-section full-width">
-        <h2>Allowed States</h2>
-        <p class="help-text">Leave all unchecked to allow all states.</p>
-        <div class="form-checkbox-grid-wide">
-          {% for code, name in US_STATES %}
-          <label class="checkbox-label checkbox-min">
-            <input type="checkbox" name="allowed_states" value="{{ code }}"
-                   {% if code in criteria.allowed_states or not criteria.allowed_states %}checked{% endif %}>
-            {{ code }}
-          </label>
-          {% endfor %}
-        </div>
-      </div>
-
-      {# Foreclosure statuses #}
-      <div class="pipeline-detail-section">
-        <h2>Foreclosure Statuses</h2>
-        <p class="help-text">Allowed foreclosure statuses (leave unchecked for all).</p>
-        <div class="form-checkbox-grid">
-          {% for fs in foreclosure_status_choices %}
-          <label class="checkbox-label">
-            <input type="checkbox" name="allowed_foreclosure_statuses" value="{{ fs }}"
-                   {% if fs in criteria.allowed_foreclosure_statuses or not criteria.allowed_foreclosure_statuses %}checked{% endif %}>
-            {{ fs|title }}
-          </label>
-          {% endfor %}
-        </div>
-      </div>
-
-      {# GACS score #}
-      <div class="pipeline-detail-section">
-        <h2>Market Score</h2>
-        <div class="form-field-group">
-          <label class="field-label">Min GACS Score</label>
-          <input type="number" name="min_gacs_score" step="0.01" min="0"
-                 value="{{ criteria.min_gacs_score|default:'' }}" class="field-input input-md">
-          <span class="help-text">Only applied if GACS scores have been computed.</span>
-        </div>
-      </div>
-
-    </div>{# end grid #}
-
-    {# Save button #}
-    <div class="form-submit-row">
-      <button type="submit" class="btn btn-primary">Save Screening Criteria</button>
-    </div>
-
-  </form>
 </div>
+
+<form method="post" id="screening-form">
+  {% csrf_token %}
+
+  {# ── Price Slider ──────────────────────────────────────────────── #}
+  <div class="card">
+    <h2 class="card-title">Price Range</h2>
+    <div class="form-row">
+      <div class="form-field-group">
+        <label class="field-label">
+          Min Price: <strong id="min-price-label">${{ criteria.min_price|default:0|floatformat:0|intcomma }}</strong>
+        </label>
+        <input type="range" name="min_price_slider" min="0" max="2000000" step="10000"
+               value="{{ criteria.min_price|default:0 }}" class="slider-input"
+               oninput="updateLabel('min_price','min-price-label','$','intcomma')">
+        <input type="hidden" name="min_price" value="{{ criteria.min_price|default:'' }}">
+      </div>
+      <div class="form-field-group">
+        <label class="field-label">
+          Max Price: <strong id="max-price-label">${{ criteria.max_price|default:2000000|floatformat:0|intcomma }}</strong>
+        </label>
+        <input type="range" name="max_price_slider" min="0" max="2000000" step="10000"
+               value="{{ criteria.max_price|default:2000000 }}" class="slider-input"
+               oninput="updateLabel('max_price','max-price-label','$','intcomma')">
+        <input type="hidden" name="max_price" value="{{ criteria.max_price|default:'' }}">
+      </div>
+    </div>
+  </div>
+
+  {# ── Yield & Ratio Sliders ─────────────────────────────────────── #}
+  <div class="card">
+    <h2 class="card-title">Yield &amp; Price-to-Rent</h2>
+    <div class="form-note-inline">
+      Only VRM properties have rent estimates. Other sources skip these checks.
+    </div>
+    <div class="form-row">
+      <div class="form-field-group">
+        <label class="field-label">
+          Min Gross Yield: <strong id="yield-label">{{ criteria.min_gross_yield_pct|default:7 }}%</strong>
+        </label>
+        <input type="range" name="min_gross_yield_slider" min="0" max="20" step="0.5"
+               value="{{ criteria.min_gross_yield_pct|default:7 }}" class="slider-input"
+               oninput="updateLabel('min_gross_yield','yield-label','','%')">
+        <input type="hidden" name="min_gross_yield_pct" value="{{ criteria.min_gross_yield_pct|default:7 }}">
+      </div>
+      <div class="form-field-group">
+        <label class="field-label">
+          Max Price/Rent Ratio: <strong id="ptr-label">{{ criteria.max_price_to_rent_ratio|default:15 }}</strong>
+        </label>
+        <input type="range" name="max_ptr_slider" min="1" max="50" step="1"
+               value="{{ criteria.max_price_to_rent_ratio|default:15 }}" class="slider-input"
+               oninput="updateLabel('max_price_to_rent_ratio','ptr-label','','')">
+        <input type="hidden" name="max_price_to_rent_ratio" value="{{ criteria.max_price_to_rent_ratio|default:15 }}">
+      </div>
+    </div>
+  </div>
+
+  {# ── Beds & GACS Sliders ───────────────────────────────────────── #}
+  <div class="card">
+    <h2 class="card-title">Size &amp; Market Score</h2>
+    <div class="form-row">
+      <div class="form-field-group">
+        <label class="field-label">
+          Min Bedrooms: <strong id="beds-label">{{ criteria.min_beds|default:1 }}</strong>
+        </label>
+        <input type="range" name="min_beds_slider" min="1" max="10" step="1"
+               value="{{ criteria.min_beds|default:1 }}" class="slider-input"
+               oninput="updateLabel('min_beds','beds-label','','')">
+        <input type="hidden" name="min_beds" value="{{ criteria.min_beds|default:1 }}">
+      </div>
+      <div class="form-field-group">
+        <label class="field-label">
+          Min GACS Score: <strong id="gacs-label">{{ criteria.min_gacs_score|default:0 }}</strong>
+        </label>
+        <input type="range" name="min_gacs_slider" min="0" max="100" step="1"
+               value="{{ criteria.min_gacs_score|default:0 }}" class="slider-input"
+               oninput="updateLabel('min_gacs_score','gacs-label','','')">
+        <input type="hidden" name="min_gacs_score" value="{{ criteria.min_gacs_score|default:'' }}">
+      </div>
+    </div>
+  </div>
+
+  {# ── Property Types ────────────────────────────────────────────── #}
+  <div class="card">
+    <h2 class="card-title">Property Types</h2>
+    <div class="form-checkbox-grid">
+      {% for pt in property_type_choices %}
+      <label class="checkbox-label">
+        <input type="checkbox" name="allowed_property_types" value="{{ pt }}"
+               {% if pt in criteria.allowed_property_types or not criteria.allowed_property_types %}checked{% endif %}>
+        {{ pt|title }}
+      </label>
+      {% endfor %}
+    </div>
+  </div>
+
+  {# ── Save ──────────────────────────────────────────────────────── #}
+  <div class="form-actions">
+    <button type="submit" class="btn btn-primary">Save &amp; Re-Screen</button>
+    <a href="{% url 'pipeline_list' %}" class="btn">Cancel</a>
+  </div>
+
+</form>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  function updateLabel(fieldName, labelId, prefix, suffix) {
+    var slider = document.querySelector('[name="' + fieldName + '_slider"]');
+    var hidden = document.querySelector('[name="' + fieldName + '"]');
+    var label = document.getElementById(labelId);
+    if (!slider || !hidden || !label) return;
+    var val = slider.value;
+    hidden.value = val || '';
+    var display = val;
+    if (prefix === '$' && suffix === 'intcomma') {
+      display = '$' + Number(val).toLocaleString();
+    } else {
+      display = prefix + val + suffix;
+    }
+    label.textContent = display;
+  }
+</script>
 {% endblock %}


### PR DESCRIPTION
## Screening Settings — Range Sliders

Replaced number inputs with visual range sliders that show live values:

| Slider | Range | Default |
|---|---|---|
| Min Price | $0–$2,000,000 | $0 |
| Max Price | $0–$2,000,000 | $0 |
| Min Gross Yield | 0–20% | 7% |
| Max Price/Rent | 1–50 | 15 |
| Min Bedrooms | 1–10 | 1 |
| Min GACS Score | 0–100 | 0 |

Each slider has a bold label that updates in real time as you drag.
Hidden inputs sync values for form POST compatibility.

### Spec Updated

Sections added to specification.md:
- **§12 — Kanban CRM Board**: columns, cards, drag-and-drop spec
- **§13 — Screening Sliders**: slider controls with ranges and defaults
- **§14 — Leasing Pipeline Kanban**: leasing stages and card display spec
- Navigation section updated to reflect current menu structure
- New acceptance criteria: AC-PK1–PK4, AC-LK1–LK2

### Files Changed
| File | Change |
|---|---|
| specification.md | +83 lines — Kanban, sliders, leasing spec |
| templates/pipeline/screening_settings.html | Number inputs → range sliders + live labels |
| static/css/pipeline.css | + slider CSS (Webkit + Mozilla styling) |
