### PR TITLE
feat(leasing): kanban board for leasing pipeline with drag-and-drop

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -127,6 +127,7 @@ urlpatterns = [
         name="pipeline_closing_create",
     ),
     path("leasing/", views.leasing_list, name="leasing_list"),
+    path("leasing/kanban/", views.leasing_kanban, name="leasing_kanban"),
     path("leasing/add/", views.leasing_add, name="leasing_add"),
     path("leasing/<int:pk>/", views.leasing_detail, name="leasing_detail"),
     path(

--- a/core/views/__init__.py
+++ b/core/views/__init__.py
@@ -2241,6 +2241,79 @@ def leasing_list(request: HttpRequest) -> HttpResponse:
 
 
 @login_required
+def leasing_kanban(request: HttpRequest) -> HttpResponse:
+    """Kanban board for the leasing pipeline — drag-and-drop stage advancement.
+
+    Columns: LISTING → SHOWING → APPLICATION → SCREENING → APPROVED →
+             LEASE_SIGNED → MOVE_IN → STABILIZED
+    """
+    from core.models import LeasingPipelineProperty
+    from datetime import date
+
+    qs = LeasingPipelineProperty.objects.filter(
+        user=request.user, status=LeasingPipelineProperty.Status.ACTIVE
+    ).select_related("property_record")
+
+    LEASING_STAGES = [
+        "LISTING",
+        "SHOWING",
+        "APPLICATION",
+        "SCREENING",
+        "APPROVED",
+        "LEASE_SIGNED",
+        "MOVE_IN",
+        "STABILIZED",
+    ]
+
+    if request.method == "POST":
+        pp_id = request.POST.get("property_id")
+        new_stage = request.POST.get("new_stage")
+        if not pp_id or not new_stage:
+            return JsonResponse(
+                {"error": "Missing property_id or new_stage"}, status=400
+            )
+        try:
+            lp = LeasingPipelineProperty.objects.get(pk=pp_id, user=request.user)
+        except LeasingPipelineProperty.DoesNotExist:
+            return JsonResponse({"error": "Property not found"}, status=404)
+        try:
+            new_idx = LEASING_STAGES.index(new_stage)
+            current_idx = LEASING_STAGES.index(lp.stage)
+        except ValueError:
+            return JsonResponse({"error": f"Unknown stage: {new_stage}"}, status=400)
+        if new_idx <= current_idx:
+            return JsonResponse(
+                {"error": "Properties can only advance forward"}, status=400
+            )
+        lp.stage = new_stage
+        lp.save(update_fields=["stage", "updated_at"])
+        return JsonResponse({"status": "ok", "stage": lp.stage})
+
+    # GET: Build stage columns
+    today = date.today()
+    columns: list[dict] = []
+    for stage in LEASING_STAGES:
+        props = [p for p in qs if p.stage == stage]
+        columns.append(
+            {
+                "stage": stage,
+                "label": LeasingPipelineProperty.Stage(stage).label,
+                "properties": props,
+                "count": len(props),
+            }
+        )
+
+    return render(
+        request,
+        "leasing/leasing_kanban.html",
+        {
+            "columns": columns,
+            "today": today,
+        },
+    )
+
+
+@login_required
 def leasing_add(request: HttpRequest) -> HttpResponse:
     """Add a new leasing pipeline entry."""
     from core.models import LeasingPipelineProperty, Property

--- a/static/css/pipeline.css
+++ b/static/css/pipeline.css
@@ -670,3 +670,91 @@
   border: 2px solid white;
   box-shadow: 0 1px 4px rgba(0,0,0,0.2);
 }
+
+/* ── Kanban Board ──────────────────────────────────────────────── */
+
+.kanban-board {
+  display: flex;
+  gap: var(--sp-3);
+  overflow-x: auto;
+  padding-bottom: var(--sp-4);
+  min-height: calc(100vh - 200px);
+}
+
+.kanban-column {
+  flex: 0 0 240px;
+  background: var(--surface-secondary);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-3);
+  display: flex;
+  flex-direction: column;
+}
+
+.kanban-column-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--sp-3);
+  padding-bottom: var(--sp-2);
+  border-bottom: 2px solid var(--color-primary);
+}
+
+.kanban-column-title {
+  font-weight: var(--weight-medium);
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-neutral-700);
+}
+
+.kanban-count { font-size: var(--text-xs); }
+
+.kanban-cards {
+  flex: 1;
+  min-height: 60px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  transition: background 0.2s;
+  border-radius: var(--radius);
+  padding: 2px;
+}
+
+.kanban-cards--over { background: rgba(37, 99, 235, 0.08); }
+
+.kanban-card {
+  background: var(--surface-primary);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius);
+  padding: var(--sp-3);
+  cursor: grab;
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+
+.kanban-card:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.10); }
+.kanban-card--dragging { opacity: 0.5; transform: rotate(2deg); }
+
+.kanban-card-address {
+  font-weight: var(--weight-medium);
+  margin-bottom: var(--sp-1);
+}
+
+.kanban-card-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-1);
+}
+
+.kanban-card-price {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-neutral-600);
+}
+
+.kanban-empty {
+  color: var(--color-neutral-300);
+  text-align: center;
+  padding: var(--sp-4);
+  font-size: var(--text-lg);
+}

--- a/templates/leasing/leasing_kanban.html
+++ b/templates/leasing/leasing_kanban.html
@@ -1,0 +1,142 @@
+{% extends "base.html" %}
+{% block title %}Leasing Kanban{% endblock %}
+{% load static humanize %}
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'css/pipeline.css' %}">
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <div>
+    <h1 class="page-title">Leasing Pipeline</h1>
+    <p class="page-sub">Drag properties between columns to advance leasing stages</p>
+  </div>
+  <div>
+    <a href="{% url 'leasing_list' %}" class="btn">List View</a>
+    <a href="{% url 'leasing_add' %}" class="btn btn-primary">+ Add Listing</a>
+  </div>
+</div>
+
+<div class="kanban-board" id="kanban-board">
+  {% for col in columns %}
+  <div class="kanban-column" data-stage="{{ col.stage }}">
+    <div class="kanban-column-header">
+      <span class="kanban-column-title">{{ col.label }}</span>
+      <span class="chip chip-default kanban-count">{{ col.count }}</span>
+    </div>
+
+    <div class="kanban-cards" id="col-{{ col.stage }}">
+      {% for lp in col.properties %}
+      <div class="kanban-card"
+           draggable="true"
+           data-id="{{ lp.pk }}"
+           data-stage="{{ lp.stage }}">
+        <div class="kanban-card-address">
+          <strong>{{ lp.property_record.address|truncatechars:35 }}</strong>
+        </div>
+        <div class="kanban-card-meta">
+          {% if lp.asking_rent %}
+          <span class="kanban-card-price">${{ lp.asking_rent|intcomma }}/mo</span>
+          {% endif %}
+        </div>
+        {% if lp.listed_date %}
+        <div class="kanban-card-meta">
+          <span class="chip chip-info">
+            {{ lp.listed_date|timesince:today|cut:" ago" }} on market
+          </span>
+        </div>
+        {% endif %}
+        {% if lp.stage >= "APPLICATION" and lp.applicant_name %}
+        <div class="kanban-card-meta">
+          <span class="chip chip-default">{{ lp.applicant_name }}</span>
+        </div>
+        {% endif %}
+      </div>
+      {% empty %}
+      <div class="kanban-empty">&mdash;</div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+(function() {
+  var cards = document.querySelectorAll('.kanban-card');
+  var columns = document.querySelectorAll('.kanban-cards');
+  var draggedCard = null;
+
+  cards.forEach(function(card) {
+    card.addEventListener('dragstart', function(e) {
+      draggedCard = card;
+      card.classList.add('kanban-card--dragging');
+      e.dataTransfer.effectAllowed = 'move';
+    });
+    card.addEventListener('dragend', function(e) {
+      card.classList.remove('kanban-card--dragging');
+      draggedCard = null;
+    });
+  });
+
+  columns.forEach(function(col) {
+    col.addEventListener('dragover', function(e) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      col.classList.add('kanban-cards--over');
+    });
+    col.addEventListener('dragleave', function() {
+      col.classList.remove('kanban-cards--over');
+    });
+    col.addEventListener('drop', function(e) {
+      e.preventDefault();
+      col.classList.remove('kanban-cards--over');
+      if (!draggedCard) return;
+
+      var newStage = col.closest('.kanban-column').dataset.stage;
+      var currentStage = draggedCard.dataset.stage;
+      if (newStage === currentStage) return;
+
+      col.appendChild(draggedCard);
+      draggedCard.dataset.stage = newStage;
+      updateCounts();
+
+      var formData = new FormData();
+      formData.append('property_id', draggedCard.dataset.id);
+      formData.append('new_stage', newStage);
+      formData.append('csrfmiddlewaretoken', '{{ csrf_token }}');
+
+      fetch(window.location.pathname, {
+        method: 'POST',
+        headers: {'X-CSRFToken': '{{ csrf_token }}'},
+        body: formData
+      }).then(function(r) { return r.json(); })
+        .then(function(data) {
+          if (data.status !== 'ok') {
+            var oldCol = document.getElementById('col-' + currentStage);
+            if (oldCol) oldCol.appendChild(draggedCard);
+            draggedCard.dataset.stage = currentStage;
+            updateCounts();
+          }
+        })
+        .catch(function() {
+          var oldCol = document.getElementById('col-' + currentStage);
+          if (oldCol) oldCol.appendChild(draggedCard);
+          draggedCard.dataset.stage = currentStage;
+          updateCounts();
+        });
+    });
+  });
+
+  function updateCounts() {
+    document.querySelectorAll('.kanban-column').forEach(function(col) {
+      var stage = col.dataset.stage;
+      var count = document.querySelectorAll('#col-' + stage + ' .kanban-card').length;
+      var chip = col.querySelector('.kanban-count');
+      if (chip) chip.textContent = count;
+    });
+  }
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Leasing Pipeline Kanban

New view at `/leasing/kanban/` — drag-and-drop leasing properties through stages.

### Columns
```
LISTING → SHOWING → APPLICATION → SCREENING → APPROVED → LEASE_SIGNED → MOVE_IN → STABILIZED
```

### Cards show
- Property address (from `property_record` FK)
- Asking rent ($/mo)
- Days-on-market badge (computed from `listed_date`)
- Applicant name (visible at APPLICATION stage+)

### Implementation
- Same drag-and-drop pattern as purchase pipeline kanban
- Reuses identical kanban CSS classes for visual consistency
- `+ Add Listing` button links to existing `/leasing/add/`
- List View button links back to existing leasing list

### Acceptance Criteria
- AC-LK1: Leasing Kanban board renders with all 8 stage columns ✅
- AC-LK2: Cards show asking rent and days-on-market badges ✅

### Files
| File | Change |
|---|---|
| core/urls.py | + `leasing/kanban/` URL |
| core/views/__init__.py | + `leasing_kanban` view (GET + POST) |
| templates/leasing/leasing_kanban.html | **NEW** — leasing kanban template |
| static/css/pipeline.css | + kanban board CSS classes |
