### PR TITLE
fix(deps): pin structlog directly and guard middleware import

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   "workspaceFolder": "/workspaces/prei",
   "features": {
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "latest"
+      "version": "3.13"
     },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import time
 import uuid
 
-import structlog
+try:
+    import structlog
+except ImportError:  # pragma: no cover — settings.py tolerates missing structlog too
+    structlog = None
 
 try:
     from opentelemetry import trace
@@ -20,7 +23,7 @@ try:
 except ImportError:  # pragma: no cover
     _otel_available = False
 
-logger = structlog.get_logger(__name__)
+logger = structlog.get_logger(__name__) if structlog is not None else None
 if _otel_available:
     tracer = trace.get_tracer("prei.http")
 
@@ -62,12 +65,13 @@ class RequestTimingMiddleware:
             )
             span.end()
 
-        logger.info(
-            "request",
-            method=request.method,
-            path=request.path,
-            status=response.status_code,
-            duration_ms=duration_ms,
-            request_id=request.request_id,
-        )
+        if logger is not None:
+            logger.info(
+                "request",
+                method=request.method,
+                path=request.path,
+                status=response.status_code,
+                duration_ms=duration_ms,
+                request_id=request.request_id,
+            )
         return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ matplotlib==3.11.1
 pillow==12.3.0
 pydantic==2.13.4
 httpx==0.28.1
+structlog==26.1.0  # direct dep — imported by settings.py and core/middleware.py
 django-structlog==9.0.0  # structured JSON logging (Phase D)
 python-json-logger==4.1.0  # JSON formatter for structlog
 opentelemetry-api==1.32.1  # OTEL traces for uFawkesObs


### PR DESCRIPTION
## Problem

Devcontainer fails to boot with `ModuleNotFoundError: No module named 'structlog'` at `core/middleware.py:13` — the WSGI app can't load middleware.

## Root causes

1. `structlog` is only a *transitive* dep of `django-structlog` — not pinned directly, even though `settings.py` and `core/middleware.py` import it directly.
2. `settings.py` guards its structlog import (`try/except ImportError → None`), so `migrate`/`seed_data` work without it — but `core/middleware.py` imports it unguarded, crashing the whole WSGI app at boot.
3. Devcontainer Python drift: base image pins 3.13, but the `python:1` feature with `version: latest` installed 3.14.6, whose site-packages predate `django-structlog`.

## Fix

- Pin `structlog==26.1.0` directly in `requirements.txt`
- Guard the structlog import in `core/middleware.py` (no-op logging when absent, matching `settings.py`)
- Pin devcontainer python feature to 3.13 to match the base image

Verified: middleware logs requests with structlog present; app boots and serves /health/ 200 with structlog present; unit tests pass.