### PR TITLE
fix(ci): add explicit markers to BDD and post-deploy pytest runs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -214,7 +214,7 @@ jobs:
           docker exec \
             -e DJANGO_SETTINGS_MODULE=investor_app.settings_test \
             prei-live-test \
-            python -m pytest tests_bdd/ -q --tb=short 2>&1
+            python -m pytest tests_bdd/ -q --tb=short -m e2e 2>&1
           echo "=== All BDD acceptance tests passed ==="
       - name: Extract test report log
         if: always()

--- a/.github/workflows/post-deployment.yml
+++ b/.github/workflows/post-deployment.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           BASE_URL: ${{ needs.smoke.outputs.target }}
         run: |
-          python -m pytest tests/acceptance/ -q --tb=short -v
+          python -m pytest tests/acceptance/ -q --tb=short -v -m acceptance
 
   # ── Performance budgets via Lighthouse ────────────────────────────────────
 


### PR DESCRIPTION
## Problem

Main's Tier 2 governance run fails with exit code 5 on the BDD acceptance step:

```
python -m pytest tests_bdd/ -q --tb=short
Process completed with exit code 5.
```

Same latent bug in the post-deployment workflow's acceptance step.

## Root cause

The testing-pyramid restructure (#332) set pytest.ini addopts to `-m 'unit or integration'` so a bare `pytest` is safe-by-default. conftest auto-marks `tests_bdd/` as `e2e` and `tests/acceptance/` as `acceptance` — so without an explicit marker override, both commands collect **zero tests** and pytest exits 5.

## Fix

- `docker-publish.yml`: BDD step → `pytest tests_bdd/ -q --tb=short -m e2e`
- `post-deployment.yml`: acceptance step → `pytest tests/acceptance/ -q --tb=short -v -m acceptance`

This is the same fix already applied to the ci-quality acceptance job. Merge this first so main's Tier 2 governance goes green and the Main CI Guard unblocks other PRs.