### PR TITLE
chore: rename compose service web to preiweb for observability clarity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  web:
+  preiweb:
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

Renamed the Docker Compose service from generic `web` to `preiweb` — while running prei alongside uFawkesObs's shared observability stack, the generic name made it hard to identify prei's logs/containers among a dozen other services (alertmanager, alloy, dora-api, grafana, loki, ...) in Grafana/Loki queries and `docker ps` output.

## What was verified

- Confirmed `web` appears only once in `docker-compose.yml` (the service key itself) — no other service depends on it by name, safe rename.
- Restarted the stack (`docker compose down --remove-orphans && up -d`) — `prei-preiweb-1` comes up healthy on both `prei_default` and `observability-lab` networks.
- `OTEL_SERVICE_NAME=prei` (traces) was already correctly set and unaffected by this rename — only the Loki `compose_service` label (sourced from the Compose service name) changes.

## Test plan

- [x] Container starts healthy under the new name
- [ ] Confirm new logs carry `compose_service=preiweb` in Loki going forward (old logs retain `compose_service=web` until they age out — expected, not a bug)