### PR TITLE
docs: document never-swallow-exceptions principle in Never Do list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 7. Hardcode hex colors in templates (exception: PDF export inline styles).
 8. Use `!important` in CSS — if a responsive rule is broken, fix the template.
 9. Use uppercase in PR title description — the first word after `type(scope):` must be lowercase (see `docs/PR_STANDARD.md`).
+10. Swallow an exception in a check, validator, or test assertion without logging what broke — a silently-caught exception makes a check that never ran indistinguishable from one that ran and found nothing.
 
 ## GitOps Principles
 See `gitops-principles` skill — load before touching workflows, deployment config, or the GitOps manifest repo.


### PR DESCRIPTION
Adds item 10 to AGENTS.md Never Do: never swallow an exception in a check/validator/test without logging what broke.

Why: in a sibling repo's acceptance suite, a bare except-pass around a validation call hid two real bugs for an unknown period -- the check reported "passed" when it had never actually verified anything.