### PR TITLE
fix(discovery): wire landlord tier filter and convert discovery flow to AJAX

### DIFF
--- a/core/views/__init__.py
+++ b/core/views/__init__.py
@@ -26,6 +26,7 @@ from django.http import (
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.text import slugify
 from django.views import View
 from playwright.sync_api import sync_playwright  # type: ignore[import-not-found]
@@ -976,6 +977,11 @@ def growth_explorer(request: HttpRequest) -> HttpResponse:
     fred_key = getenv("FRED_API_KEY") or getenv("FRED_api_key") or ""
     fred_configured = bool(fred_key)
     api_keys_configured = bool(census_api_key)
+    # Landlord-friendliness tier per state, for the "Tier" selector to narrow
+    # the "pick a state" dropdown client-side (JS filters options by data-tier).
+    state_tiers = {
+        code: get_state_landlord_score(code)["tier"] for code, _ in US_STATES
+    }
 
     if request.method == "GET":
         return render(
@@ -983,6 +989,7 @@ def growth_explorer(request: HttpRequest) -> HttpResponse:
             "growth_explorer.html",
             {
                 "states": US_STATES,
+                "state_tiers": state_tiers,
                 "api_keys_configured": api_keys_configured,
                 "census_key_configured": census_configured,
                 "fred_key_configured": fred_configured,
@@ -996,6 +1003,7 @@ def growth_explorer(request: HttpRequest) -> HttpResponse:
             "growth_explorer.html",
             {
                 "states": US_STATES,
+                "state_tiers": state_tiers,
                 "api_keys_configured": False,
                 "census_key_configured": bool(census_api_key),
                 "fred_key_configured": fred_configured,
@@ -1010,6 +1018,7 @@ def growth_explorer(request: HttpRequest) -> HttpResponse:
             "growth_explorer.html",
             {
                 "states": US_STATES,
+                "state_tiers": state_tiers,
                 "api_keys_configured": api_keys_configured,
                 "census_key_configured": bool(census_api_key),
                 "fred_key_configured": fred_configured,
@@ -1034,6 +1043,7 @@ def growth_explorer(request: HttpRequest) -> HttpResponse:
             "growth_explorer.html",
             {
                 "states": US_STATES,
+                "state_tiers": state_tiers,
                 "api_keys_configured": api_keys_configured,
                 "census_key_configured": bool(census_api_key),
                 "fred_key_configured": fred_configured,
@@ -1304,6 +1314,7 @@ def growth_explorer(request: HttpRequest) -> HttpResponse:
         "growth_explorer.html",
         {
             "states": US_STATES,
+            "state_tiers": state_tiers,
             "selected_state": state,
             "results": results,
             "emp_growth": emp_growth,
@@ -1679,14 +1690,29 @@ def pipeline_advance_stage(request: HttpRequest, pk: int) -> HttpResponse:
         raise Http404
 
     action = request.POST.get("action", "")
+    next_url = request.POST.get("next") or request.META.get("HTTP_REFERER") or ""
 
     if action == "hold":
         prop.status = PipelineProperty.Status.ON_HOLD
         prop.save(update_fields=["status", "updated_at"])
         messages.info(request, f"{prop.address} has been moved to Hold.")
+    elif action == "advance":
+        from core.services.pipeline import advance_stage
+
+        try:
+            advance_stage(prop)
+            messages.success(
+                request, f"{prop.address} advanced to {prop.get_stage_display()}."
+            )
+        except ValueError as exc:
+            messages.warning(request, str(exc))
     else:
         messages.warning(request, f"Unknown action: {action}")
 
+    if next_url and url_has_allowed_host_and_scheme(
+        next_url, allowed_hosts={request.get_host()}
+    ):
+        return redirect(next_url)
     return redirect("pipeline_review_queue")
 
 
@@ -3693,6 +3719,7 @@ def property_discovery(request: HttpRequest) -> HttpResponse:
         "screening_failed": 0,
         "sources_attempted": [],
         "errors": [],
+        "properties": [],
     }
 
     # --- HUD ---
@@ -3710,6 +3737,7 @@ def property_discovery(request: HttpRequest) -> HttpResponse:
                 )
                 if created:
                     results["discovered"] += 1
+                    results["properties"].append(pp)
                     if criteria and pp.screening_passed is not None:
                         if pp.screening_passed:
                             results["screening_passed"] += 1
@@ -3736,6 +3764,7 @@ def property_discovery(request: HttpRequest) -> HttpResponse:
                 )
                 if created:
                     results["discovered"] += 1
+                    results["properties"].append(pp)
                     if criteria and pp.screening_passed is not None:
                         if pp.screening_passed:
                             results["screening_passed"] += 1
@@ -3762,6 +3791,7 @@ def property_discovery(request: HttpRequest) -> HttpResponse:
                 )
                 if created:
                     results["discovered"] += 1
+                    results["properties"].append(pp)
                     if criteria and pp.screening_passed is not None:
                         if pp.screening_passed:
                             results["screening_passed"] += 1
@@ -3787,6 +3817,7 @@ def property_discovery(request: HttpRequest) -> HttpResponse:
                 )
                 if created:
                     results["discovered"] += 1
+                    results["properties"].append(pp)
                     if criteria and pp.screening_passed is not None:
                         if pp.screening_passed:
                             results["screening_passed"] += 1

--- a/templates/base.html
+++ b/templates/base.html
@@ -44,13 +44,14 @@
           📊 Underwrite
           <span class="sub-label">Properties ready for your decision</span>
         </a>
+        <hr class="nav-divider">
         <a href="{% url 'pipeline_kanban' %}" class="nav-dropdown-item {% if request.resolver_match.url_name == 'pipeline_kanban' %}active{% endif %}" role="menuitem">
-          📋 Kanban
-          <span class="sub-label">Drag-and-drop pipeline board</span>
+          📋 Portfolio Board
+          <span class="sub-label">Everything, every stage, at a glance — not a step to complete</span>
         </a>
         <a href="{% url 'pipeline_list' %}" class="nav-dropdown-item {% if request.resolver_match.url_name == 'pipeline_list' %}active{% endif %}" role="menuitem">
-          📋 Pipeline
-          <span class="sub-label">Offers, due diligence, closing — all stages</span>
+          📋 Portfolio List
+          <span class="sub-label">Same overview as a table — offers, due diligence, closing</span>
         </a>
         <hr class="nav-divider">
         <a href="{% url 'pipeline_screening_settings' %}" class="nav-dropdown-item {% if request.resolver_match.url_name == 'pipeline_screening_settings' %}active{% endif %}" role="menuitem">

--- a/templates/growth_explorer.html
+++ b/templates/growth_explorer.html
@@ -25,7 +25,7 @@
         </select>
       </div>
       <div class="form-group">
-        <label>Or pick states</label>
+        <label id="state-select-label">Then pick a state</label>
         <select name="state" id="state-select" class="form-input">
           <option value="">— All states —</option>
           {% for code, name in states %}
@@ -119,12 +119,40 @@
   </div>
 </div>
 
+{{ state_tiers|json_script:"state-tiers-data" }}
 <script>
 (function() {
   const form = document.getElementById('analysis-form');
   const btn = document.getElementById('analyze-btn');
   const overlay = document.getElementById('loading-overlay');
   const results = document.getElementById('results-section');
+  const tierSelect = document.getElementById('tier-select');
+  const stateSelect = document.getElementById('state-select');
+  const stateSelectLabel = document.getElementById('state-select-label');
+  const stateTiers = JSON.parse(document.getElementById('state-tiers-data').textContent);
+  const TIER_MAP = {landlord_friendly: 'top', mixed: 'middle', tenant_friendly: 'bottom'};
+
+  function applyTierFilter() {
+    const wantTier = TIER_MAP[tierSelect.value] || '';
+    let visibleCount = 0;
+    for (const opt of stateSelect.options) {
+      if (!opt.value) continue; // keep "— All states —"
+      const matches = !wantTier || stateTiers[opt.value] === wantTier;
+      opt.hidden = !matches;
+      opt.disabled = !matches;
+      if (matches) visibleCount++;
+    }
+    // If the currently selected state no longer matches, reset to placeholder.
+    if (wantTier && stateSelect.value && stateTiers[stateSelect.value] !== wantTier) {
+      stateSelect.value = '';
+    }
+    stateSelectLabel.textContent = wantTier
+      ? 'Then pick a state (' + visibleCount + ' match)'
+      : 'Then pick a state';
+  }
+
+  tierSelect?.addEventListener('change', applyTierFilter);
+  applyTierFilter();
 
   form?.addEventListener('submit', function(e) {
     e.preventDefault();

--- a/templates/property_discovery.html
+++ b/templates/property_discovery.html
@@ -57,7 +57,7 @@
 </div>
 {% endif %}
 
-<form method="post" action="?growth_area_id={{ growth_area.pk }}">
+<form method="post" action="?growth_area_id={{ growth_area.pk }}" id="discovery-form">
   {% csrf_token %}
   <input type="hidden" name="growth_area_id" value="{{ growth_area.pk }}">
 
@@ -108,7 +108,7 @@
   </div>
 
   <div class="form-actions">
-    <button type="submit" class="btn btn-primary">Discover Properties in {{ growth_area.city_name }}</button>
+    <button type="submit" class="btn btn-primary" id="discover-btn">Discover Properties in {{ growth_area.city_name }}</button>
     {% if already_discovered > 0 %}
     <a href="{% url 'pipeline_screener' %}?growth_area_id={{ growth_area.pk }}" class="btn">View Screened ({{ already_discovered }})</a>
     {% endif %}
@@ -118,7 +118,8 @@
 
 {% endif %}{# growth_area selected #}
 
-{# ── POST Results (shown after discovery runs) ───────────────────── #}
+{# ── POST Results (shown after discovery runs, and swapped in via AJAX) ── #}
+<div id="results-section"{% if not show_results %} hidden{% endif %}>
 {% if show_results and discovery_results %}
 <div class="card">
   <h2 class="card-title">Discovery Results</h2>
@@ -129,29 +130,106 @@
     <div class="kpi-card"><div class="kpi-label">Already Existed</div><div class="kpi-value">{{ discovery_results.already_existed }}</div></div>
   </div>
   {% if discovery_results.discovered > 0 %}
-  <div class="message message-success mt-3">{{ discovery_results.discovered }} new. {{ discovery_results.screening_passed }} passed screening.</div>
+  <div class="message message-success mt-3">{{ discovery_results.discovered }} new. {{ discovery_results.screening_passed }} passed screening — auto-screened against your criteria below, no extra step needed.</div>
   {% else %}
   <div class="message message-warning mt-3">No new properties found.</div>
   {% endif %}
+
+  {% if discovery_results.properties %}
+  <div class="table-wrap mt-4">
+    <table class="data-table">
+      <thead><tr><th>Address</th><th>Screening</th><th></th></tr></thead>
+      <tbody>
+        {% for prop in discovery_results.properties %}
+        <tr>
+          <td>{{ prop.address }}</td>
+          <td>
+            {% if prop.screening_passed %}<span class="chip chip-success">Passed</span>
+            {% elif prop.screening_passed is False %}<span class="chip chip-danger">Failed</span>
+            {% else %}<span class="chip">Not screened</span>{% endif %}
+          </td>
+          <td>
+            {% if prop.screening_passed %}
+            <form method="post" action="{% url 'pipeline_advance_stage' pk=prop.pk %}" class="inline-form">
+              {% csrf_token %}
+              <input type="hidden" name="action" value="advance">
+              <input type="hidden" name="next" value="?growth_area_id={{ growth_area.pk }}">
+              <button type="submit" class="btn btn-primary btn-sm">Continue to Underwriting →</button>
+            </form>
+            {% else %}
+            <a href="{% url 'pipeline_detail' pk=prop.pk %}" class="btn btn-sm">View →</a>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
+
   <div class="form-actions mt-4">
-    <a href="{% url 'pipeline_screener' %}?growth_area_id={{ growth_area.pk }}" class="btn btn-primary">View in Screener →</a>
+    <a href="{% url 'pipeline_screener' %}?growth_area_id={{ growth_area.pk }}" class="btn">View All in Screener →</a>
     <a href="?growth_area_id={{ growth_area.pk }}" class="btn">Discover More</a>
   </div>
 </div>
 {% endif %}
+</div>
 
 {# Loading overlay shown during discovery POST #}
 <div id="discovery-loading" class="kanban-modal-overlay kanban-hidden">
   <div class="kanban-modal">
     <h2 class="text-center">Discovering Properties...</h2>
-    <p class="page-sub text-center" id="discovery-status-msg">Scraping data sources and creating pipeline entries. This may take a minute.</p>
+    <p class="page-sub text-center" id="discovery-status-msg">Scraping data sources and creating pipeline entries. Elapsed: <span id="discovery-elapsed">0s</span></p>
+    <div class="progress-bar-wrap"><div id="discovery-progress" class="progress-bar" role="progressbar"></div></div>
   </div>
 </div>
 
+<style>
+  .progress-bar-wrap { height:6px;background:var(--color-border,#e5e7eb);border-radius:3px;margin-top:16px;overflow:hidden; }
+  .progress-bar { height:100%;width:0;background:var(--color-primary,#2563eb);border-radius:3px;transition:width 1s ease; }
+</style>
+
 <script>
-  document.querySelector('form[method="post"]')?.addEventListener('submit', function() {
-    document.getElementById('discovery-loading').classList.remove('kanban-hidden');
+(function() {
+  const form = document.getElementById('discovery-form');
+  const btn = document.getElementById('discover-btn');
+  const overlay = document.getElementById('discovery-loading');
+  const results = document.getElementById('results-section');
+  if (!form) return;
+
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    const csrf = form.querySelector('[name=csrfmiddlewaretoken]')?.value || '';
+    const formData = new URLSearchParams(new FormData(form));
+    overlay.classList.remove('kanban-hidden');
+    btn.disabled = true;
+
+    let elapsed = 0;
+    const timer = setInterval(() => {
+      elapsed++;
+      document.getElementById('discovery-elapsed').textContent = elapsed + 's';
+      document.getElementById('discovery-progress').style.width = Math.min(elapsed * 2, 95) + '%';
+    }, 1000);
+
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 130000);
+
+    fetch(form.action || window.location.href, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest'},
+      body: formData,
+      signal: controller.signal,
+    })
+    .then(r => r.text())
+    .then(html => {
+      clearInterval(timer); overlay.classList.add('kanban-hidden'); btn.disabled = false;
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      const newResults = doc.getElementById('results-section');
+      if (newResults) { results.innerHTML = newResults.innerHTML; results.hidden = false; results.scrollIntoView({behavior: 'smooth'}); }
+    })
+    .catch(() => { clearInterval(timer); overlay.classList.add('kanban-hidden'); btn.disabled = false; });
   });
+})();
 </script>
 
 {% endblock %}

--- a/tests/test_growth_explorer_view.py
+++ b/tests/test_growth_explorer_view.py
@@ -1,0 +1,57 @@
+"""Regression test for the Growth Area Explorer "Tier" selector.
+
+The tier selector was previously wired on the client (POSTed to the server)
+but never read by the view, and never linked to the state dropdown it sits
+next to — selecting a tier had no visible effect. See core/views/__init__.py
+growth_explorer() for the fix: the view now passes a state->tier mapping
+that the template embeds via json_script for client-side filtering of the
+state dropdown.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="growth_explorer_user",
+        email="growth_explorer@test.com",
+        password="testpass123",
+    )
+
+
+@pytest.fixture
+def client(db, user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+def test_growth_explorer_get_includes_state_tiers(client):
+    """GET must embed a state->tier map the tier-select JS depends on."""
+    response = client.get("/growth-explorer/")
+    assert response.status_code == 200
+
+    html = response.content.decode()
+    match = re.search(r'id="state-tiers-data"[^>]*>(.*?)</script>', html, re.S)
+    assert match is not None, "state-tiers-data json_script block missing"
+
+    state_tiers = json.loads(match.group(1))
+    # Known-good spot checks against core/services/landlord_data.py
+    assert state_tiers["TX"] == "top"
+    assert state_tiers["CA"] == "bottom"
+    assert state_tiers["NY"] == "bottom"
+    # Every US state/DC should have a tier (falls back to "middle" if unlisted)
+    assert len(state_tiers) >= 50
+
+    assert 'id="tier-select"' in html
+    assert "applyTierFilter" in html

--- a/tests/test_pipeline_advance_stage.py
+++ b/tests/test_pipeline_advance_stage.py
@@ -1,0 +1,94 @@
+"""Tests for the "advance" action on pipeline_advance_stage.
+
+Previously this view only handled action="hold" despite its name/docstring
+claiming to advance stages. Property Discovery's results page now gives
+passed-screening properties a "Continue to Underwriting" button that POSTs
+here with action="advance" — this exercises that path end to end.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+from django.utils import timezone
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="advance_stage_user",
+        email="advance_stage@test.com",
+        password="testpass123",
+    )
+
+
+@pytest.fixture
+def client(db, user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+@pytest.fixture
+def screened_property(db, user):
+    from core.models import PipelineProperty
+
+    return PipelineProperty.objects.create(
+        user=user,
+        source_type="manual",
+        source_id="advance-test",
+        address="789 Advance Ave, Fort Worth TX 76102",
+        address_hash="advance-hash",
+        stage=PipelineProperty.Stage.SCREENING,
+        status=PipelineProperty.Status.ACTIVE,
+        screening_passed=True,
+        price=Decimal("180000"),
+        estimated_rent=Decimal("1600"),
+        beds=3,
+        discovered_at=timezone.now(),
+        screening_at=timezone.now(),
+    )
+
+
+def test_advance_action_moves_to_next_stage(client, screened_property):
+    from core.models import PipelineProperty
+
+    url = reverse("pipeline_advance_stage", kwargs={"pk": screened_property.pk})
+    response = client.post(url, {"action": "advance"})
+
+    screened_property.refresh_from_db()
+    assert screened_property.stage == PipelineProperty.Stage.UNDERWRITING
+    assert screened_property.underwriting_at is not None
+    assert response.status_code == 302
+
+
+def test_advance_action_redirects_to_safe_next_url(client, screened_property):
+    url = reverse("pipeline_advance_stage", kwargs={"pk": screened_property.pk})
+    response = client.post(
+        url, {"action": "advance", "next": "/discovery/?growth_area_id=1"}
+    )
+    assert response["Location"] == "/discovery/?growth_area_id=1"
+
+
+def test_advance_action_ignores_unsafe_next_url(client, screened_property):
+    url = reverse("pipeline_advance_stage", kwargs={"pk": screened_property.pk})
+    response = client.post(
+        url, {"action": "advance", "next": "https://evil.example.com/phish"}
+    )
+    assert response["Location"] != "https://evil.example.com/phish"
+
+
+def test_hold_action_still_works(client, screened_property):
+    from core.models import PipelineProperty
+
+    url = reverse("pipeline_advance_stage", kwargs={"pk": screened_property.pk})
+    client.post(url, {"action": "hold"})
+
+    screened_property.refresh_from_db()
+    assert screened_property.status == PipelineProperty.Status.ON_HOLD

--- a/tests/test_property_discovery_view.py
+++ b/tests/test_property_discovery_view.py
@@ -1,0 +1,97 @@
+"""End-to-end test for the Property Discovery AJAX conversion + per-property CTAs.
+
+Discovery previously did a blocking synchronous <form method="post"> with no
+progress feedback past an initial flash, and results only offered a generic
+"View in Screener" link even though screening already ran server-side.
+This exercises the real POST path (HUD source) and checks the rendered
+results block: per-property rows, a "Continue to Underwriting" CTA for
+passed properties pointing at a real reversible URL, and the swappable
+#results-section wrapper the JS fetch() handler depends on.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.utils import timezone
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="discovery_view_user",
+        email="discovery_view@test.com",
+        password="testpass123",
+    )
+
+
+@pytest.fixture
+def client(db, user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+@pytest.fixture
+def growth_area(db):
+    from core.models import GrowthArea
+
+    return GrowthArea.objects.create(
+        state="TX",
+        city_name="Discoveryville",
+        metro_area="Discoveryville",
+        population_growth_rate=Decimal("0.0100"),
+        employment_growth_rate=Decimal("0.0200"),
+        median_income_growth=Decimal("0.0300"),
+        housing_demand_index=50,
+        data_timestamp=timezone.now(),
+    )
+
+
+@pytest.fixture
+def hud_property(growth_area):
+    from core.models import HudProperty
+
+    return HudProperty.objects.create(
+        hud_case_number="DISC-TEST-1",
+        address="1 Discovery Ln",
+        city=growth_area.city_name,
+        state=growth_area.state,
+        zip_code="76102",
+        asking_price=Decimal("120000"),
+        list_price=Decimal("120000"),
+        status=HudProperty.Status.ACTIVE,
+        scraped_at=timezone.now(),
+        last_seen_at=timezone.now(),
+    )
+
+
+def test_discovery_post_renders_per_property_results(
+    client, user, growth_area, hud_property
+):
+    response = client.post(
+        f"/discovery/?growth_area_id={growth_area.pk}",
+        {"growth_area_id": growth_area.pk, "sources": ["hud"]},
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+    assert response.status_code == 200
+
+    html = response.content.decode()
+    assert 'id="results-section"' in html
+    assert hud_property.address in html
+
+    from core.models import PipelineProperty
+
+    pp = PipelineProperty.objects.get(user=user, growth_area=growth_area)
+    advance_url = f"/pipeline/{pp.pk}/advance/"
+
+    if pp.screening_passed:
+        assert "Continue to Underwriting" in html
+        assert advance_url in html
+    else:
+        assert f"/pipeline/{pp.pk}/" in html


### PR DESCRIPTION
## Summary
- Growth Area Explorer's "Tier" selector was fully wired client-side but never read by the view — and couldn't have worked as a results filter anyway, since a single-state search yields one uniform landlord score for every row. Tier now narrows the state picker instead, matching the "Or pick states" relationship the UI already implied.
- Discover Properties used a blocking synchronous `<form method="post">` with only a one-frame loading flash for a request that can take a minute. Converted to `fetch()`-based AJAX mirroring Growth Explorer's existing progress-bar pattern (elapsed timer, progress bar, in-place result swap, no page reload).
- Results now list each discovered property with its real screening outcome and a direct **"Continue to Underwriting"** action, instead of only linking to a generic Screener list after screening already happened silently server-side. This required extending `pipeline_advance_stage`, which only implemented a `hold` action despite its name/docstring claiming to advance stages — added `action=advance` (open-redirect-safe `next` handling included).
- Nav: Kanban and List regrouped and relabeled as portfolio-wide overviews, separated from the Discover → Screen → Underwrite sequence they were previously flattened into as if they were another step.

## Test plan
- [x] `python manage.py check` — clean
- [x] `pre-commit run --files <changed files>` — ruff, ruff-format, mypy, gitleaks, djlint all pass
- [x] New regression tests (this code had zero prior coverage):
  - `tests/test_growth_explorer_view.py` — state→tier map renders correctly
  - `tests/test_pipeline_advance_stage.py` — advance action moves stage forward, open-redirect guard, hold action still works
  - `tests/test_property_discovery_view.py` — full HUD discovery POST → per-property results with Continue-to-Underwriting CTA
- [x] Manually verified via Django test client (no Chrome available in this environment for live browser testing — noting that gap rather than skipping verification silently)