### PR TITLE
fix(tests): update container startup tests for preiweb service rename

### DIFF
--- a/tests/test_container_startup.py
+++ b/tests/test_container_startup.py
@@ -91,7 +91,7 @@ def test_render_blueprint_excludes_celery_redis_config() -> None:
 def test_compose_healthcheck_allows_longer_prestart_migrations() -> None:
     """Verify Compose grants extra startup time before healthcheck failures."""
     compose = _load_yaml("docker-compose.yml")
-    web = compose.get("services", {}).get("web", {})
+    web = compose.get("services", {}).get("preiweb", {})
     hc = web.get("healthcheck", {})
 
     assert hc.get("start_period") == "90s", (
@@ -105,7 +105,7 @@ def test_compose_healthcheck_allows_longer_prestart_migrations() -> None:
 def test_compose_web_service_has_required_config() -> None:
     """Verify essential web-service configuration keys exist."""
     compose = _load_yaml("docker-compose.yml")
-    web = compose.get("services", {}).get("web", {})
+    web = compose.get("services", {}).get("preiweb", {})
 
     assert web.get("image") == "ghcr.io/paruff/prei:latest"
     assert web.get("env_file") == ".env"
@@ -120,7 +120,7 @@ def test_compose_web_service_has_required_config() -> None:
 def test_compose_runtime_env_vars_set() -> None:
     """Verify runtime environment overrides exist in the web service."""
     compose = _load_yaml("docker-compose.yml")
-    env = compose.get("services", {}).get("web", {}).get("environment", {})
+    env = compose.get("services", {}).get("preiweb", {}).get("environment", {})
 
     # May be a dict or list of KEY=value strings
     env_str = str(env)


### PR DESCRIPTION
## Summary
- Discovered while diagnosing PR #339's failing Integration Tests: `tests/test_container_startup.py` still looks up `docker-compose.yml`'s web service by its old key `"web"`, which became `"preiweb"` in #344 (rename compose service web to preiweb for observability clarity).
- The compose file's actual configuration was never wrong — the test's `.get("services", {}).get("web", {})` lookups just silently returned `{}`, failing 3 assertions unconditionally on every PR's Integration Tests job regardless of what the PR actually touched.

## Test plan
- [x] `python -m pytest tests/test_container_startup.py -v` — 9/9 pass (was 3 failed, 6 passed)
- [x] `pre-commit run --files tests/test_container_startup.py` — clean
- [x] Confirmed no other stale `"web"` service-key references anywhere in the repo (`grep -rn` across `.py`/`.yml`)