### PR TITLE
ci(perf): fix Playwright/mypy caching and add timeouts to prevent hangs

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -133,6 +133,18 @@ jobs:
         run: sudo apt-get install -y libcairo2-dev
       - name: Install dependencies
         run: pip install -r requirements.txt coverage
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-1.62.0
+      - name: Install Playwright
+        run: playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - name: Install Playwright system deps only
+        run: playwright install-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
       - name: Collect static files
         run: python manage.py collectstatic --noinput --verbosity 0
       - name: Run integration tests

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -133,8 +133,6 @@ jobs:
         run: sudo apt-get install -y libcairo2-dev
       - name: Install dependencies
         run: pip install -r requirements.txt coverage
-      - name: Install Playwright
-        run: playwright install --with-deps chromium
       - name: Collect static files
         run: python manage.py collectstatic --noinput --verbosity 0
       - name: Run integration tests


### PR DESCRIPTION
## Summary
Started as a single Playwright-removal fix; grew into a full CI suite audit after that fix broke tests and a separate job was found hung for 1h16m with no timeout to kill it.

- **Integration Tests**: restored the Playwright install (wrongly removed in an earlier commit — 3 PDF export tests transitively need it via application code, not a direct test-file import), added `actions/cache` for `~/.cache/ms-playwright` so the ~150-300MB browser download only happens once per cache key.
- **E2E Tests**: same caching pattern applied — had the identical uncached-download problem (~8 min/run).
- **Typecheck**: added `.mypy_cache` caching — this was the actual critical path of the whole PR-gate suite (~16 min cold, zero cache persistence across runs previously, and every job runs in parallel so this alone determined total wall time).
- **Every job in every workflow** (37 across 9 files): added `timeout-minutes`. Root cause of the observed hour-plus hang — only 2 of 37 jobs had any timeout; GitHub defaults to 360 minutes when unset, so any hang (interactive apt/dpkg prompt, network stall) blocks a PR indefinitely with zero automatic recovery. Sized off this session's observed real durations for ci-quality.yml, conservative defaults elsewhere.

Expected outcome: total PR-gate wall time drops from ~16-18 min to roughly the new longest job (ZAP Scan, ~7-8 min) — plus no more silent multi-hour hangs.

## Test plan
- [x] All 9 workflow files: valid YAML (`yaml.safe_load`)
- [x] `pre-commit run` across all changed files — clean
- [x] Confirmed no duplicate/missing `timeout-minutes` (job count == timeout-minutes line count per file)
- [x] Confirmed pre-existing timeouts (docker-publish `build-image`, post-deployment `security`) untouched
- [ ] Confirm this PR's own Integration/E2E/Typecheck jobs pass and show real time savings