### PR TITLE
fix(security): stop logging ZIP code in VRM source fetch

### DIFF
--- a/core/services/sources/vrm_source.py
+++ b/core/services/sources/vrm_source.py
@@ -85,10 +85,9 @@ class VrmDiscoverySource(DiscoverySource):
             )
 
         logger.info(
-            "VRM source fetched %d properties for %s (zip=%s, statuses=%s)",
+            "VRM source fetched %d properties for %s (statuses=%s)",
             len(listings),
             state,
-            zip_code or "any",
             statuses,
         )
         return listings


### PR DESCRIPTION
## Summary
Resolves CodeQL security alert #381 (\`py/clear-text-logging-sensitive-data\`, high severity).

\`core/services/sources/vrm_source.py\`'s VRM fetch logged \`zip_code\` — a caller-supplied search filter, not any individual's PII, but the variable-name pattern trips CodeQL's heuristic regardless. Dropped it from the log line; \`state\` and result count already give sufficient debugging context. The actual filter logic (\`qs.filter(zip_code__startswith=zip_code)\`) is untouched.

## Test plan
- [x] \`pre-commit run\` — ruff, mypy clean
- [x] Confirmed \`zip_code\` still used for query filtering, only removed from the log statement