### PR TITLE
fix(ci): resolve Trivy HIGH CVEs blocking Tier 2 Governance on main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ RUN apt-get update && \
     apt-get remove --purge -y --auto-remove perl libperl* && \
     rm -rf /var/lib/apt/lists/*
 
+# Drop ensurepip's bundled setuptools/pip wheels — unused at runtime (nothing
+# in this image creates a venv) but their frozen versions still trip Trivy
+# (e.g. CVE-2025-47273) even after the site-packages copy is patched below.
+RUN rm -f /usr/local/lib/python3.*/ensurepip/_bundled/*.whl
+
 WORKDIR /app
 
 # ── deps layer (cached unless requirements.txt changes) ───────────────────
@@ -59,6 +64,13 @@ COPY --from=deps /usr/local/bin /usr/local/bin
 # jaraco.context 5.3.0 for CVE-2026-23949; wheel 0.46.2+ for CVE-2026-24049).
 # Don't pin pip — the base image ships 26.2.1+ and downgrading breaks imports.
 RUN pip install --upgrade setuptools==83.0.0 wheel==0.46.2
+# Remove pip itself — unused at runtime (entrypoint.sh only calls manage.py/
+# gunicorn) and its pip/_vendor bundle carries its own frozen msgpack/setuptools
+# copies that Trivy flags (GHSA-6v7p-g79w-8964, CVE-2025-47273) independent of
+# the real site-packages copies patched above.
+RUN rm -rf /usr/local/lib/python3.*/site-packages/pip \
+           /usr/local/lib/python3.*/site-packages/pip-*.dist-info \
+           /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.*
 COPY . .
 
 # Bake version into files so the runtime can read them without a .git dir

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ gunicorn==26.0.0
 pytest==9.1.1
 pytest-django==4.12.0
 pytest-bdd==8.1.0
+msgpack==1.2.1  # transitive via pytest-bdd→gherkin-official; pin for GHSA-6v7p-g79w-8964
 coverage==7.15.4
 pytest-asyncio==1.4.0
 pytest-rerunfailures==16.5  # flaky test retry (Phase C)


### PR DESCRIPTION
## Summary
Tier 2 Governance's Trivy scan has been failing on every push to `main` (predates #376 — the same two CVEs failed the prior push too) on two HIGH CVEs that trace back to `pip` itself, not the app's real dependencies:

- **`msgpack 1.1.2`** (GHSA-6v7p-g79w-8964) — pip's own vendored copy at `pip/_vendor/msgpack`, not our installed `msgpack` (already resolves to a clean version transitively).
- **`setuptools 70.3.0`** (CVE-2025-47273) — not installed anywhere; it's a version string in pip's `_vendor/vendor.txt` manifest that Trivy's scanner parses as an "installed" package.

`pip` is never invoked at container runtime (`entrypoint.sh` only runs `manage.py`/`gunicorn`), so this strips it from the final image after the existing setuptools/wheel CVE-patch step. Also removes the now-pointless `ensurepip` bundled wheel (same class of issue), and pins `msgpack==1.2.1` directly since it's also a real (if separate) transitive dependency via `pytest-bdd`→`gherkin-official`.

### Changes
- `Dockerfile`: drop ensurepip bundled wheels in the `base` stage; remove `pip` from the `runtime` stage after the setuptools/wheel upgrade.
- `requirements.txt`: pin `msgpack==1.2.1`.

## Test plan
- [x] Rebuilt the image locally with the fix
- [x] `trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1` → exit code 0 (clean)
- [x] Confirmed `msgpack` resolves to 1.2.1 and `setuptools` to 83.0.0 inside the built image
- [x] Confirmed `ensurepip/_bundled` is empty and `pip`/`pip3` are gone from the image
- [x] Booted Django inside the built image (`django.setup()`) to confirm removing pip doesn't break the app
- [ ] CI Tier 2 Governance run on this PR (will confirm green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)