### PR TITLE
feat(analysis): add exit strategy and fix sensitivity rate axis

### DIFF
--- a/core/services/exit_strategy.py
+++ b/core/services/exit_strategy.py
@@ -1,0 +1,160 @@
+"""Exit strategy modeling: hold-period projections across appreciation scenarios.
+
+Generates a comparison table of exit outcomes across multiple hold periods
+and appreciation scenarios so analysts can evaluate when and how to exit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import TYPE_CHECKING, Dict, List, Any
+
+from core.services.projections import (
+    ExitAnalysis,
+    project_hold_period,
+)
+
+if TYPE_CHECKING:
+    from core.models import Property
+
+
+# ── Default scenario grids ────────────────────────────────────────────────────
+
+# Hold periods (years) to model exits at
+DEFAULT_HOLD_PERIODS: list[int] = [3, 5, 7, 10, 15]
+
+# Annual appreciation scenarios to test
+DEFAULT_APPRECIATION_SCENARIOS: Dict[str, Decimal] = {
+    "Pessimistic": Decimal("-0.01"),
+    "Conservative": Decimal("0.02"),
+    "Base": Decimal("0.03"),
+    "Optimistic": Decimal("0.05"),
+}
+
+
+# ── Result containers ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class ExitStrategyResult:
+    """One exit strategy scenario result."""
+
+    hold_years: int
+    scenario_name: str
+    appreciation_rate: Decimal
+    exit: ExitAnalysis
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+
+def model_exit_strategies(
+    property: Property,
+    hold_periods: list[int] | None = None,
+    appreciation_scenarios: Dict[str, Decimal] | None = None,
+    annual_rent_growth_pct: Decimal = Decimal("0.03"),
+    annual_expense_inflation_pct: Decimal = Decimal("0.02"),
+    marginal_tax_rate: Decimal = Decimal("0.24"),
+    selling_costs_pct: Decimal = Decimal("0.06"),
+) -> List[ExitStrategyResult]:
+    """Model exit strategies across hold periods and appreciation scenarios.
+
+    Runs ``project_hold_period`` for each combination of hold period and
+    appreciation scenario, collecting the resulting ``ExitAnalysis``.
+
+    Args:
+        property: A ``Property`` instance with financial fields populated.
+        hold_periods: List of hold years to model (e.g. [3, 5, 7, 10]).
+            Defaults to [3, 5, 7, 10, 15].
+        appreciation_scenarios: Mapping of scenario name to annual appreciation
+            rate (as a fraction). Defaults to pessimistic/conservative/base/
+            optimistic presets.
+        annual_rent_growth_pct: Annual rent growth as a fraction.
+        annual_expense_inflation_pct: Annual expense inflation as a fraction.
+        marginal_tax_rate: Investor's marginal tax rate as a fraction [0, 1].
+        selling_costs_pct: Selling costs as a fraction of sale price.
+
+    Returns:
+        A list of ``ExitStrategyResult`` (one per combination), ordered first
+        by hold period ascending, then by scenario order in the input dict.
+    """
+    periods = hold_periods or DEFAULT_HOLD_PERIODS
+    scenarios = appreciation_scenarios or DEFAULT_APPRECIATION_SCENARIOS
+
+    results: List[ExitStrategyResult] = []
+
+    for hold_years in periods:
+        for scenario_name, appr_rate in scenarios.items():
+            _, exit_analysis = project_hold_period(
+                property,
+                hold_years=hold_years,
+                annual_rent_growth_pct=annual_rent_growth_pct,
+                annual_appreciation_pct=appr_rate,
+                annual_expense_inflation_pct=annual_expense_inflation_pct,
+                marginal_tax_rate=marginal_tax_rate,
+                selling_costs_pct=selling_costs_pct,
+            )
+            results.append(
+                ExitStrategyResult(
+                    hold_years=hold_years,
+                    scenario_name=scenario_name,
+                    appreciation_rate=appr_rate,
+                    exit=exit_analysis,
+                )
+            )
+
+    return results
+
+
+def exit_strategy_table(
+    property: Property,
+    hold_periods: list[int] | None = None,
+    appreciation_scenarios: Dict[str, Decimal] | None = None,
+    annual_rent_growth_pct: Decimal = Decimal("0.03"),
+    annual_expense_inflation_pct: Decimal = Decimal("0.02"),
+    marginal_tax_rate: Decimal = Decimal("0.24"),
+    selling_costs_pct: Decimal = Decimal("0.06"),
+) -> List[Dict[str, Any]]:
+    """Return exit strategy results as a list of flat dict rows.
+
+    Same arguments as :func:`model_exit_strategies`, but each row is a dict
+    with the hold period, scenario name, appreciation rate, and the key exit
+    metrics (gross sale price, net proceeds after tax, total return,
+    annualized IRR).
+
+    Returns:
+        A list of dicts with keys: hold_years, scenario_name,
+        appreciation_rate, gross_sale_price, selling_costs, loan_payoff,
+        net_proceeds_before_tax, estimated_capital_gains_tax,
+        net_proceeds_after_tax, total_return, annualized_irr.
+    """
+    results = model_exit_strategies(
+        property,
+        hold_periods=hold_periods,
+        appreciation_scenarios=appreciation_scenarios,
+        annual_rent_growth_pct=annual_rent_growth_pct,
+        annual_expense_inflation_pct=annual_expense_inflation_pct,
+        marginal_tax_rate=marginal_tax_rate,
+        selling_costs_pct=selling_costs_pct,
+    )
+
+    rows: List[Dict[str, Any]] = []
+    for r in results:
+        rows.append(
+            {
+                "hold_years": r.hold_years,
+                "scenario_name": r.scenario_name,
+                "appreciation_rate": r.appreciation_rate,
+                "gross_sale_price": r.exit.gross_sale_price,
+                "selling_costs": r.exit.selling_costs,
+                "loan_payoff": r.exit.loan_payoff,
+                "net_proceeds_before_tax": r.exit.net_proceeds_before_tax,
+                "estimated_capital_gains_tax": r.exit.estimated_capital_gains_tax,
+                "net_proceeds_after_tax": r.exit.net_proceeds_after_tax,
+                "total_return": r.exit.total_return,
+                "annualized_irr": r.exit.annualized_irr,
+            }
+        )
+
+    return rows

--- a/core/services/sensitivity.py
+++ b/core/services/sensitivity.py
@@ -1,0 +1,104 @@
+"""Sensitivity analysis table for rent, vacancy, and rate scenarios.
+
+Generates a table of underwriting metrics across varying parameter
+combinations so analysts can see how NOI, Cap Rate, CoC, and MAO
+respond to changes in key assumptions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+from decimal import Decimal
+from typing import List, Dict, Any
+
+from core.services.underwriting import UnderwritingInput, solve_underwriting
+
+
+# ── Default scenario grids ────────────────────────────────────────────────────
+
+# Rent multipliers relative to the base estimated_rent
+DEFAULT_RENT_MULTIPLIERS: list[Decimal] = [
+    Decimal("0.80"),
+    Decimal("0.90"),
+    Decimal("1.00"),
+    Decimal("1.10"),
+    Decimal("1.20"),
+]
+
+# Vacancy rates to test
+DEFAULT_VACANCY_RATES: list[Decimal] = [
+    Decimal("0.03"),
+    Decimal("0.05"),
+    Decimal("0.07"),
+    Decimal("0.10"),
+    Decimal("0.15"),
+]
+
+# Cap rates to backsolve MAO against
+DEFAULT_CAP_RATES: list[Decimal | float] = [0.05, 0.06, 0.07, 0.08, 0.09, 0.10]
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+
+def sensitivity_analysis_table(
+    base_inputs: UnderwritingInput,
+    rent_multipliers: Sequence[Decimal] | None = None,
+    vacancy_rates: Sequence[Decimal] | None = None,
+    cap_rate_scanners: Sequence[Decimal | float] | None = None,
+) -> List[Dict[str, Any]]:
+    """Generate a sensitivity analysis table across rent, vacancy, and rate scenarios.
+
+    The "rate scenario" dimension varies the cap rate used to backsolve the
+    Max Allowable Offer (MAO = NOI / cap_rate). Each row therefore shows the
+    offer an investor would make at that required return.
+
+    Args:
+        base_inputs: Base UnderwritingInput with property financial data.
+        rent_multipliers: Rent multiplier list relative to base estimated_rent.
+            Defaults to [80%, 90%, 100%, 110%, 120%].
+        vacancy_rates: List of vacancy rates to test. Defaults to
+            [3%, 5%, 7%, 10%, 15%].
+        cap_rate_scanners: List of cap rates to backsolve MAO for.
+            Defaults to [5%, 6%, 7%, 8%, 9%, 10%].
+
+    Returns:
+        A list of dicts, each dict representing one table row with keys:
+        - "rent": the gross annual rent used (Decimal)
+        - "vacancy_rate": the vacancy rate used (Decimal)
+        - "cap_rate": the cap rate tested (Decimal | float)
+        - "noi": Net Operating Income (Decimal)
+        - "cap_rate_result": computed cap rate from NOI/price (Decimal)
+        - "cash_on_cash": Cash-on-Cash yield (Decimal)
+        - "mao": Max Allowable Offer at the given cap rate (Decimal)
+    """
+    rents = rent_multipliers or DEFAULT_RENT_MULTIPLIERS
+    vacancies = vacancy_rates or DEFAULT_VACANCY_RATES
+    caps = cap_rate_scanners or DEFAULT_CAP_RATES
+
+    rows: List[Dict[str, Any]] = []
+
+    for mult in rents:
+        rent = base_inputs.estimated_rent * mult
+        inputs_rent = replace(base_inputs, estimated_rent=rent)
+
+        for vac in vacancies:
+            inputs_vac = replace(inputs_rent, vacancy_rate=vac)
+
+            for cap in caps:
+                metrics = solve_underwriting(inputs_vac, cap)
+
+                rows.append(
+                    {
+                        "rent": rent,
+                        "vacancy_rate": vac,
+                        "cap_rate": cap,
+                        "noi": metrics.noi,
+                        "cap_rate_result": metrics.cap_rate,
+                        "cash_on_cash": metrics.cash_on_cash,
+                        "mao": metrics.mao,
+                    }
+                )
+
+    return rows

--- a/core/tests/test_exit_strategy.py
+++ b/core/tests/test_exit_strategy.py
@@ -1,0 +1,235 @@
+"""Tests for exit strategy modeling across hold periods and appreciation scenarios.
+
+These are unit tests: ``project_hold_period`` only reads plain attributes off
+the property object, so we build an unsaved ``Property`` instance (no DB access,
+avoiding the sqlite lock contention seen under load) with the financial fields
+the projection reads.
+"""
+
+from decimal import Decimal
+
+from core.models import Property
+from core.services.exit_strategy import (
+    ExitStrategyResult,
+    exit_strategy_table,
+    model_exit_strategies,
+)
+
+
+def make_property() -> Property:
+    """Build an unsaved ``Property`` with the fields ``project_hold_period`` reads.
+
+    Mirrors the spec's known example: $200,000 purchase, 20% down ($40,000),
+    $1,500/mo rent, 7% interest, 30-yr loan.
+    """
+    return Property(
+        purchase_price=Decimal("200000"),
+        monthly_rent_gross=Decimal("1500"),
+        other_monthly_income=Decimal("0"),
+        property_taxes_annual=Decimal("2400"),
+        insurance_annual=Decimal("1200"),
+        hoa_monthly=Decimal("0"),
+        maintenance_monthly=Decimal("150"),
+        capex_monthly=Decimal("100"),
+        down_payment_pct=Decimal("0.20"),
+        interest_rate=Decimal("0.07"),
+        loan_term_years=30,
+        vacancy_rate=Decimal("0.08"),
+        mgmt_fee_pct=Decimal("0.10"),
+    )
+
+
+# ═════════════════════════════════════════════════════════════════
+#  BASIC FUNCTIONALITY
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestExitStrategyBasic:
+    def test_model_returns_list(self) -> None:
+        """Should return a non-empty list of ExitStrategyResult."""
+        results = model_exit_strategies(make_property())
+        assert isinstance(results, list)
+        assert len(results) > 0
+        assert all(isinstance(r, ExitStrategyResult) for r in results)
+
+    def test_table_returns_list_of_dicts(self) -> None:
+        """Table should return a list of dict rows."""
+        rows = exit_strategy_table(make_property())
+        assert isinstance(rows, list)
+        assert len(rows) > 0
+        assert all(isinstance(r, dict) for r in rows)
+
+    def test_table_rows_have_expected_keys(self) -> None:
+        """Each table row should contain all expected keys."""
+        rows = exit_strategy_table(make_property())
+        expected_keys = {
+            "hold_years",
+            "scenario_name",
+            "appreciation_rate",
+            "gross_sale_price",
+            "selling_costs",
+            "loan_payoff",
+            "net_proceeds_before_tax",
+            "estimated_capital_gains_tax",
+            "net_proceeds_after_tax",
+            "total_return",
+            "annualized_irr",
+        }
+        for row in rows:
+            assert set(row.keys()) == expected_keys
+
+    def test_result_count_matches_grid(self) -> None:
+        """Result count = len(hold_periods) × len(appreciation_scenarios)."""
+        hold_periods = [3, 5, 7]
+        scenarios = {"Low": Decimal("0.01"), "High": Decimal("0.04")}
+        results = model_exit_strategies(
+            make_property(),
+            hold_periods=hold_periods,
+            appreciation_scenarios=scenarios,
+        )
+        assert len(results) == len(hold_periods) * len(scenarios)
+
+
+# ═════════════════════════════════════════════════════════════════
+#  SCENARIO-SPECIFIC ASSERTIONS
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestExitStrategyAppreciation:
+    """Higher appreciation should produce higher sale prices all else equal."""
+
+    def test_higher_appreciation_higher_sale_price(self) -> None:
+        """For the same hold period, higher appreciation → higher gross sale price."""
+        hold_periods = [10]
+        scenarios = {
+            "Low": Decimal("0.01"),
+            "Mid": Decimal("0.03"),
+            "High": Decimal("0.05"),
+        }
+        rows = exit_strategy_table(
+            make_property(),
+            hold_periods=hold_periods,
+            appreciation_scenarios=scenarios,
+        )
+        # rows are ordered by scenario order in dict
+        sale_prices = [r["gross_sale_price"] for r in rows]
+        # Base price = 200000; 1% → lower, 5% → higher
+        assert sale_prices == sorted(sale_prices)
+
+    def test_longer_hold_higher_sale_price(self) -> None:
+        """For the same scenario, longer hold → higher gross sale price."""
+        scenarios = {"Base": Decimal("0.03")}
+        hold_periods = [3, 5, 7, 10]
+        rows = exit_strategy_table(
+            make_property(),
+            hold_periods=hold_periods,
+            appreciation_scenarios=scenarios,
+        )
+        sale_prices = [r["gross_sale_price"] for r in rows]
+        assert sale_prices == sorted(sale_prices)
+
+
+class TestExitStrategyResultStructure:
+    def test_hold_years_vary(self) -> None:
+        """Hold years should vary across the default grid."""
+        results = model_exit_strategies(make_property())
+        hold_years = {r.hold_years for r in results}
+        assert len(hold_years) == 5  # default 5 hold periods
+
+    def test_scenario_names_present(self) -> None:
+        """Scenario names should include the default four."""
+        results = model_exit_strategies(make_property())
+        names = {r.scenario_name for r in results}
+        assert {"Pessimistic", "Conservative", "Base", "Optimistic"}.issubset(names)
+
+    def test_appreciation_rate_stored(self) -> None:
+        """appreciation_rate field should match the scenario rate."""
+        results = model_exit_strategies(make_property())
+        for r in results:
+            assert isinstance(r.appreciation_rate, Decimal)
+
+    def test_exit_is_exit_analysis(self) -> None:
+        """exit field should be an ExitAnalysis instance."""
+        from core.services.projections import ExitAnalysis
+
+        results = model_exit_strategies(make_property())
+        for r in results:
+            assert isinstance(r.exit, ExitAnalysis)
+
+
+# ═════════════════════════════════════════════════════════════════
+#  CUSTOM PARAMETERS
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestExitStrategyCustomParams:
+    def test_custom_hold_periods(self) -> None:
+        """Custom hold periods should be used."""
+        hold_periods = [2, 4, 6]
+        rows = exit_strategy_table(make_property(), hold_periods=hold_periods)
+        assert {r["hold_years"] for r in rows} == set(hold_periods)
+
+    def test_custom_scenarios(self) -> None:
+        """Custom appreciation scenarios should be used."""
+        scenarios = {"Bear": Decimal("-0.02"), "Bull": Decimal("0.06")}
+        rows = exit_strategy_table(make_property(), appreciation_scenarios=scenarios)
+        assert {r["scenario_name"] for r in rows} == set(scenarios.keys())
+
+    def test_pessimistic_negative_appreciation_lower_price(self) -> None:
+        """Negative appreciation yields lower sale price than base scenario."""
+        hold_periods = [10]
+        scenarios = {
+            "Down": Decimal("-0.01"),
+            "Up": Decimal("0.04"),
+        }
+        rows = exit_strategy_table(
+            make_property(),
+            hold_periods=hold_periods,
+            appreciation_scenarios=scenarios,
+        )
+        prices = {r["scenario_name"]: r["gross_sale_price"] for r in rows}
+        assert prices["Down"] < prices["Up"]
+
+
+# ═════════════════════════════════════════════════════════════════
+#  INTEGRITY / EDGE CASES
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestExitStrategyIntegrity:
+    def test_all_metrics_decimal(self) -> None:
+        """All monetary metrics in table rows should be Decimal."""
+        rows = exit_strategy_table(make_property())
+        decimal_keys = {
+            "gross_sale_price",
+            "selling_costs",
+            "loan_payoff",
+            "net_proceeds_before_tax",
+            "estimated_capital_gains_tax",
+            "net_proceeds_after_tax",
+            "total_return",
+            "annualized_irr",
+        }
+        for row in rows:
+            for key in decimal_keys:
+                assert isinstance(row[key], Decimal)
+
+    def test_no_duplicate_combinations(self) -> None:
+        """Should not have duplicate (hold_years, scenario) combinations."""
+        rows = exit_strategy_table(make_property())
+        seen = set()
+        for row in rows:
+            key = (row["hold_years"], row["scenario_name"])
+            assert key not in seen, f"Duplicate combination: {key}"
+            seen.add(key)
+
+    def test_result_objects_match_table(self) -> None:
+        """model_exit_strategies and exit_strategy_table should be consistent."""
+        results = model_exit_strategies(make_property())
+        rows = exit_strategy_table(make_property())
+        assert len(results) == len(rows)
+        for r, row in zip(results, rows):
+            assert r.hold_years == row["hold_years"]
+            assert r.scenario_name == row["scenario_name"]
+            assert r.appreciation_rate == row["appreciation_rate"]
+            assert r.exit.gross_sale_price == row["gross_sale_price"]

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -1,0 +1,191 @@
+"""Sensitivity analysis table tests for rent, vacancy, and rate scenarios."""
+
+from decimal import Decimal
+
+from core.services.underwriting import UnderwritingInput
+from core.services.sensitivity import sensitivity_analysis_table
+
+BASE = UnderwritingInput(
+    purchase_price=Decimal("300000"),
+    estimated_rent=Decimal("2500"),
+    property_tax_annual=Decimal("3600"),
+    insurance_annual=Decimal("1200"),
+)
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  BASIC FUNCTIONALITY
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+class TestSensitivityAnalysisTableBasic:
+    def test_returns_list(self) -> None:
+        """Table should be a non-empty list of dicts."""
+        rows = sensitivity_analysis_table(BASE)
+        assert isinstance(rows, list)
+        assert len(rows) > 0
+
+    def test_rows_are_dicts(self) -> None:
+        """Each row should be a dict with expected keys."""
+        rows = sensitivity_analysis_table(BASE)
+        assert all(isinstance(r, dict) for r in rows)
+
+    def test_rows_have_expected_keys(self) -> None:
+        """Each row should contain all expected keys."""
+        rows = sensitivity_analysis_table(BASE)
+        expected_keys = {
+            "rent",
+            "vacancy_rate",
+            "cap_rate",
+            "noi",
+            "cap_rate_result",
+            "cash_on_cash",
+            "mao",
+        }
+        for row in rows:
+            assert set(row.keys()) == expected_keys
+
+    def test_rent_varies_across_multipliers(self) -> None:
+        """Rent should vary across the default multipliers."""
+        rows = sensitivity_analysis_table(BASE)
+        rents = {row["rent"] for row in rows}
+        # 5 multipliers × 5 vacancies × 6 caps = 150 rows
+        assert len(rents) == 5
+
+    def test_vacancy_varies_across_rates(self) -> None:
+        """Vacancy rate should vary across the default rates."""
+        rows = sensitivity_analysis_table(BASE)
+        vacs = {row["vacancy_rate"] for row in rows}
+        assert len(vacs) == 5
+
+    def test_cap_rate_varies_across_scanners(self) -> None:
+        """Cap rate scanner should vary across the default values."""
+        rows = sensitivity_analysis_table(BASE)
+        caps = {row["cap_rate"] for row in rows}
+        assert len(caps) == 6
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  SCENARIO-SPECIFIC ASSERTIONS
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+class TestSensitivityScenarioRentIncrease:
+    """Rent increase should improve all else-equal metrics."""
+
+    def test_higher_rent_better_noi(self) -> None:
+        """Higher rent → higher NOI (all else equal)."""
+        rows = sensitivity_analysis_table(BASE)
+        # Find rows with same vacancy and cap but different rents
+        by_vac_cap: dict[tuple[Decimal, Decimal], list[dict]] = {}
+        for row in rows:
+            key = (row["vacancy_rate"], row["cap_rate"])
+            by_vac_cap.setdefault(key, []).append(row)
+
+        for key, group in by_vac_cap.items():
+            # Within each (vacancy, cap) group, rents should be ordered
+            # multipliers are [0.8, 0.9, 1.0, 1.1, 1.2], so NOI should increase
+            NOIs = [row["noi"] for row in group]
+            assert NOIs == sorted(NOIs), f"NOIs not sorted for {key}: {NOIs}"
+
+
+class TestSensitivityScenarioVacancyIncrease:
+    """Vacancy increase should worsen NOI all else equal."""
+
+    def test_higher_vacancy_worse_noi(self) -> None:
+        """Higher vacancy → lower NOI (all else equal)."""
+        rows = sensitivity_analysis_table(BASE)
+        by_rent_cap: dict[tuple[Decimal, Decimal], list[dict]] = {}
+        for row in rows:
+            key = (row["rent"], row["cap_rate"])
+            by_rent_cap.setdefault(key, []).append(row)
+
+        for key, group in by_rent_cap.items():
+            NOIs = [row["noi"] for row in group]
+            assert NOIs == sorted(NOIs, reverse=True), (
+                f"NOIs not descending for rent={key[0]} cap={key[1]}: {NOIs}"
+            )
+
+
+class TestSensitivityScenarioCapRateIncrease:
+    """Cap rate increase should lower MAO all else equal."""
+
+    def test_higher_cap_rate_lower_mao(self) -> None:
+        """Higher cap rate → lower MAO (all else equal)."""
+        rows = sensitivity_analysis_table(BASE)
+        by_rent_vac: dict[tuple[Decimal, Decimal], list[dict]] = {}
+        for row in rows:
+            key = (row["rent"], row["vacancy_rate"])
+            by_rent_vac.setdefault(key, []).append(row)
+
+        for key, group in by_rent_vac.items():
+            maos = [row["mao"] for row in group]
+            # Default caps are [0.05, 0.06, 0.07, 0.08, 0.09, 0.10] (ascending)
+            # MAO = NOI / cap_rate, so MAO must be strictly decreasing
+            for i in range(len(maos) - 1):
+                assert maos[i] > maos[i + 1], (
+                    f"MAO not strictly decreasing for rent={key[0]} "
+                    f"vac={key[1]}: {maos}"
+                )
+
+
+# ════════════════════════════════════════════════════════════════════════════
+#  CUSTOM PARAMETERS
+# ════════════════════════════════════════════════════════════════════════════
+
+
+class TestSensitivityCustomParams:
+    def test_custom_rent_multipliers(self) -> None:
+        """Custom rent multipliers should be used."""
+        custom_multipliers = [Decimal("0.90"), Decimal("1.00"), Decimal("1.10")]
+        rows = sensitivity_analysis_table(BASE, rent_multipliers=custom_multipliers)
+        rents = {row["rent"] for row in rows}
+        assert rents == {BASE.estimated_rent * m for m in custom_multipliers}
+
+    def test_custom_vacancy_rates(self) -> None:
+        """Custom vacancy rates should be used."""
+        custom_vacancies = [Decimal("0.05"), Decimal("0.10")]
+        rows = sensitivity_analysis_table(BASE, vacancy_rates=custom_vacancies)
+        vacs = {row["vacancy_rate"] for row in rows}
+        assert vacs == set(custom_vacancies)
+
+    def test_custom_cap_rate_scanners(self) -> None:
+        """Custom cap rate scanners should be used."""
+        custom_caps = [Decimal("0.07"), Decimal("0.09")]
+        rows = sensitivity_analysis_table(BASE, cap_rate_scanners=custom_caps)
+        caps = {row["cap_rate"] for row in rows}
+        assert caps == set(custom_caps)
+
+
+# ════════════════════════════════════════════════════════════════════════════
+#  INTEGRITY / EDGE CASES
+# ════════════════════════════════════════════════════════════════════════════
+
+
+class TestSensitivityIntegrity:
+    def test_noi_always_decimal(self) -> None:
+        """NOI should always be a Decimal."""
+        rows = sensitivity_analysis_table(BASE)
+        for row in rows:
+            assert isinstance(row["noi"], Decimal)
+
+    def test_mao_always_decimal(self) -> None:
+        """MAO should always be a Decimal."""
+        rows = sensitivity_analysis_table(BASE)
+        for row in rows:
+            assert isinstance(row["mao"], Decimal)
+
+    def test_cash_on_cash_always_decimal(self) -> None:
+        """Cash-on-Cash should always be a Decimal."""
+        rows = sensitivity_analysis_table(BASE)
+        for row in rows:
+            assert isinstance(row["cash_on_cash"], Decimal)
+
+    def test_no_duplicate_rows(self) -> None:
+        """Should not have duplicate rows with identical parameter combos."""
+        rows = sensitivity_analysis_table(BASE)
+        seen: set[tuple] = set()
+        for row in rows:
+            key = (row["rent"], row["vacancy_rate"], row["cap_rate"])
+            assert key not in seen, f"Duplicate row found: {key}"
+            seen.add(key)


### PR DESCRIPTION
## What
- Fixes a broken "rate scenarios" dimension in `sensitivity_analysis_table`: MAO was backsolved against a fixed `target_cap_rate` instead of the iterated scenario cap, so the MAO column never changed across cap rates. Removed the redundant `target_cap_rate` param and a dead `replace()` no-op.
- Adds `core/services/exit_strategy.py`: hold-period exit projections across appreciation scenarios, with tests.

## Why
The sensitivity table (issue #363) promised a rent/vacancy/rate cube; the rate axis was silently non-functional. The exit-strategy service rounds out the investment analysis toolkit.

## How
- `solve_underwriting(inputs_vac, cap)` now uses the scenario `cap` for the MAO backsolve.
- Param types widened to `Sequence` to fix a mypy variance error in the cap-rate test.
- `model_exit_strategies`/`exit_strategy_table` typed param unchanged (`Property`); test fixture now builds an unsaved `Property` instead of `SimpleNamespace`.

## Testing
- `tests/test_sensitivity.py`: strengthened `test_higher_cap_rate_lower_mao` to assert MAO is strictly decreasing across cap rates (previously passed even when all MAOs were equal).
- `pre-commit run --files` clean (ruff, ruff-format, mypy, gitleaks, hooks). 32 tests pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Related files limited to the change

🤖 Generated with [opencode](https://opencode.ai)